### PR TITLE
feat: Show disabled "Delete branch" menu option with tooltip

### DIFF
--- a/docs/PERMISSION_MIGRATION.md
+++ b/docs/PERMISSION_MIGRATION.md
@@ -1,0 +1,203 @@
+# Permission System Migration
+
+## Overview
+
+This document outlines the migration of permission flags from scattered locations to a centralized `shared/permissions/` layer. This architecture enables:
+
+1. **Frontend**: Show disabled UI with tooltips explaining why
+2. **Backend Operations**: Validate before executing with meaningful errors
+3. **MCP Server (future)**: Return structured errors to AI agents
+
+## Alignment with Existing Architecture
+
+Per `src/node/README.md`, the backend follows a layered architecture:
+
+```
+handlers/     → IPC entry points, routes requests to operations/services
+operations/   → High-level orchestration, composes domain + services
+services/     → Async I/O, external dependencies, caching
+domain/       → Pure business logic, no I/O, deterministic
+shared/       → Types, errors, constants used across all layers
+```
+
+Key principle: **"If it's used by 2+ layers, it belongs in shared/"**
+
+Permission logic is:
+- **Pure** (no I/O, deterministic) - qualifies for `domain/`
+- **Used by both `web/` and `node/`** - must be in `shared/`
+
+Therefore `shared/permissions/` is the correct location. This follows the existing pattern of `shared/git-url.ts` which contains pure utility functions used by multiple layers.
+
+## Target Architecture
+
+```
+src/
+├── shared/                          ← Cross-cutting: web/ + node/
+│   ├── permissions/                 ← NEW: Pure permission logic
+│   │   ├── delete-branch.ts
+│   │   ├── rename-branch.ts
+│   │   └── ...
+│   └── types/
+│       └── ui.ts                    ← Raw state only, no computed canXxx
+│
+├── web/
+│   └── components/
+│       └── BranchBadge.tsx          ← Calls getXxxPermission() for UI state
+│
+└── node/
+    ├── domain/
+    │   └── UiStateBuilder.ts        ← Provides raw state, no permission logic
+    └── operations/
+        └── BranchOperation.ts       ← Calls getXxxPermission() for validation
+```
+
+**Data flow:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  shared/permissions/                                        │
+│  Pure functions: (rawState) → { allowed, deniedReason }     │
+└─────────────────────────────────────────────────────────────┘
+                              │
+              ┌───────────────┴───────────────┐
+              ▼                               ▼
+┌─────────────────────────┐     ┌─────────────────────────────┐
+│  web/components/        │     │  node/operations/           │
+│                         │     │                             │
+│  Uses for:              │     │  Uses for:                  │
+│  - disabled prop        │     │  - validation before exec   │
+│  - disabledReason prop  │     │  - throw typed errors       │
+└─────────────────────────┘     └─────────────────────────────┘
+```
+
+## Permission Flags Inventory
+
+### ✅ Migrated
+
+| Flag | Location | Status |
+|------|----------|--------|
+| `canDelete` (branch) | `shared/permissions/delete-branch.ts` | **Done** |
+
+### 🔄 Needs Migration
+
+#### Branch Permissions (UiBranch)
+
+| Flag | Current Location | Rules | Needs Tooltip? |
+|------|------------------|-------|----------------|
+| `canRename` | `UiStateBuilder.ts:637` | `!isRemote && !isTrunk` | Yes - "Cannot rename trunk/remote branches" |
+| `canFold` | `UiStateBuilder.ts:638` | `!isRemote && !isTrunk` | Yes - "Cannot fold trunk/remote branches" |
+| `canCreateWorktree` | `UiStateBuilder.ts:639` | `!isRemote && !isTrunk` | Yes - "Cannot create worktree for trunk/remote branches" |
+
+#### Commit Permissions
+
+| Flag | Current Location | Rules | Status |
+|------|------------------|-------|--------|
+| `canEdit` (message) | `web/utils/edit-message-state.ts` | `!isTrunk && isHead` | **Already frontend pattern** - needs move to `shared/` |
+
+#### Stack Permissions (UiStack)
+
+| Flag | Current Location | Rules | Needs Tooltip? |
+|------|------------------|-------|----------------|
+| `canRebaseToTrunk` | `UiStateBuilder.ts:449` | `isDirectlyOffTrunk && baseSha !== trunkHeadSha` | Maybe - complex state |
+
+## Migration Steps Per Flag
+
+### 1. Create Permission Module in `shared/permissions/`
+
+```typescript
+// shared/permissions/rename-branch.ts
+export type RenameBranchDeniedReason = 'is-trunk' | 'is-remote'
+
+const DENIED_REASON_MESSAGES: Record<RenameBranchDeniedReason, string> = {
+  'is-trunk': 'Cannot rename trunk branches',
+  'is-remote': 'Cannot rename remote branches'
+}
+
+export type RenameBranchPermission =
+  | { allowed: true; deniedReason: undefined }
+  | { allowed: false; reason: RenameBranchDeniedReason; deniedReason: string }
+
+export function getRenameBranchPermission({
+  isTrunk,
+  isRemote
+}: { isTrunk: boolean; isRemote: boolean }): RenameBranchPermission {
+  if (isTrunk) {
+    return { allowed: false, reason: 'is-trunk', deniedReason: DENIED_REASON_MESSAGES['is-trunk'] }
+  }
+  if (isRemote) {
+    return { allowed: false, reason: 'is-remote', deniedReason: DENIED_REASON_MESSAGES['is-remote'] }
+  }
+  return { allowed: true, deniedReason: undefined }
+}
+```
+
+### 2. Update Backend Operation
+
+```typescript
+// node/operations/BranchOperation.ts
+static async rename(repoPath: string, oldName: string, newName: string): Promise<void> {
+  const permission = getRenameBranchPermission({ isTrunk: isTrunkRef(oldName), isRemote: false })
+  if (!permission.allowed) {
+    if (permission.reason === 'is-trunk') {
+      throw new TrunkProtectionError(oldName, 'rename')
+    }
+    throw new BranchError(permission.deniedReason, oldName, 'rename')
+  }
+  // ... execute
+}
+```
+
+### 3. Update Frontend Component
+
+```typescript
+// web/components/BranchBadge.tsx
+const renamePermission = useMemo(
+  () => getRenameBranchPermission({ isTrunk: data.isTrunk, isRemote: data.isRemote }),
+  [data.isTrunk, data.isRemote]
+)
+
+// In JSX:
+<ContextMenuItem
+  onClick={handleRename}
+  disabled={!renamePermission.allowed}
+  disabledReason={renamePermission.deniedReason}
+>
+  Rename branch
+</ContextMenuItem>
+```
+
+### 4. Remove from UiStateBuilder
+
+Remove computed `canXxx` from `UiBranch` type and `UiStateBuilder`. Frontend computes from raw state.
+
+### 5. Update Tests
+
+- Add tests to `shared/permissions/__tests__/`
+- Update component tests to verify tooltip behavior
+
+## Files to Modify Per Migration
+
+For each permission flag:
+
+1. **Create**: `shared/permissions/{operation}.ts`
+2. **Update**: `shared/permissions/index.ts` (exports)
+3. **Update**: `node/operations/XxxOperation.ts` (use permission)
+4. **Update**: `web/components/Xxx.tsx` (use permission)
+5. **Remove**: `shared/types/ui.ts` (remove `canXxx` field)
+6. **Remove**: `node/domain/UiStateBuilder.ts` (remove computation)
+7. **Update**: Test helpers in `__tests__/` directories
+
+## Priority Order
+
+1. **`canRename`** - Simple, similar to delete
+2. **`canFold`** - Simple, similar to delete
+3. **`canCreateWorktree`** - Simple, similar to delete
+4. **`canEdit`** - Move existing `edit-message-state.ts` to `shared/permissions/`
+5. **`canRebaseToTrunk`** - More complex, involves SHA comparison
+
+## Notes
+
+- Keep defense-in-depth checks in operations even after adding permission layer
+- Use existing error types (`TrunkProtectionError`, `BranchError`) for consistency
+- Permission modules should be pure functions with no side effects
+- All user-facing messages should be in the `DENIED_REASON_MESSAGES` map for easy localization

--- a/src/node/__tests__/operations/BranchOperation.test.ts
+++ b/src/node/__tests__/operations/BranchOperation.test.ts
@@ -408,7 +408,7 @@ describe('deleteBranch', () => {
 
     // Try to delete current branch - should throw
     await expect(BranchOperation.delete(repoPath, 'feature')).rejects.toThrow(
-      'Cannot delete the currently checked out branch'
+      'Cannot delete the checked out branch'
     )
 
     // Branch should still exist

--- a/src/node/domain/UiStateBuilder.ts
+++ b/src/node/domain/UiStateBuilder.ts
@@ -635,7 +635,6 @@ export class UiStateBuilder {
       // This keeps all business logic in the backend, making the UI dumb
       const isCurrent = branch.ref === state.currentBranch
       const canRename = !branch.isRemote && !branch.isTrunk
-      const canDelete = !isCurrent && !branch.isTrunk
       const canFold = !branch.isRemote && !branch.isTrunk
       const canCreateWorktree = !branch.isRemote && !branch.isTrunk
 
@@ -650,7 +649,6 @@ export class UiStateBuilder {
         worktree,
         ownedCommitShas,
         canRename,
-        canDelete,
         canFold,
         canCreateWorktree
       })

--- a/src/node/utils/generate-mock-stack.ts
+++ b/src/node/utils/generate-mock-stack.ts
@@ -18,7 +18,6 @@ function createMockBranch(
     isRemote,
     isTrunk,
     canRename: !isRemote && !isTrunk,
-    canDelete: !isCurrent && !isTrunk,
     canFold: !isRemote && !isTrunk,
     canCreateWorktree: !isRemote && !isTrunk
   }

--- a/src/shared/permissions/__tests__/delete-branch.test.ts
+++ b/src/shared/permissions/__tests__/delete-branch.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import { getDeleteBranchPermission, type DeleteBranchPermission } from '../delete-branch'
+
+describe('getDeleteBranchPermission', () => {
+  describe('basic cases', () => {
+    it('returns allowed: true for non-trunk, non-current branch', () => {
+      const result = getDeleteBranchPermission({ isTrunk: false, isCurrent: false })
+      expect(result.allowed).toBe(true)
+      expect(result.deniedReason).toBeUndefined()
+    })
+
+    it('returns allowed: false with reason "is-trunk" for trunk branches', () => {
+      const result = getDeleteBranchPermission({ isTrunk: true, isCurrent: false })
+      expect(result.allowed).toBe(false)
+      if (!result.allowed) {
+        expect(result.reason).toBe('is-trunk')
+        expect(result.deniedReason).toBe('Cannot delete trunk')
+      }
+    })
+
+    it('returns allowed: false with reason "is-checked-out" for current branch', () => {
+      const result = getDeleteBranchPermission({ isTrunk: false, isCurrent: true })
+      expect(result.allowed).toBe(false)
+      if (!result.allowed) {
+        expect(result.reason).toBe('is-checked-out')
+        expect(result.deniedReason).toBe('Cannot delete the checked out branch')
+      }
+    })
+  })
+
+  describe('priority and edge cases', () => {
+    it('prioritizes trunk check over current check', () => {
+      // If both trunk and current, trunk reason should be shown
+      // (though this is an edge case - trunk is rarely checked out)
+      const result = getDeleteBranchPermission({ isTrunk: true, isCurrent: true })
+      expect(result.allowed).toBe(false)
+      if (!result.allowed) {
+        expect(result.reason).toBe('is-trunk')
+      }
+    })
+
+    it('returns consistent results for same inputs (pure function)', () => {
+      const input = { isTrunk: false, isCurrent: false }
+      const result1 = getDeleteBranchPermission(input)
+      const result2 = getDeleteBranchPermission(input)
+      expect(result1).toEqual(result2)
+    })
+
+    it('does not mutate input object', () => {
+      const input = { isTrunk: false, isCurrent: true }
+      const inputCopy = { ...input }
+      getDeleteBranchPermission(input)
+      expect(input).toEqual(inputCopy)
+    })
+  })
+
+  describe('exhaustive state coverage', () => {
+    // Test all 4 combinations to ensure complete coverage
+    const testCases: Array<{
+      isTrunk: boolean
+      isCurrent: boolean
+      expectedAllowed: boolean
+      expectedReason?: 'is-trunk' | 'is-checked-out'
+    }> = [
+      { isTrunk: false, isCurrent: false, expectedAllowed: true },
+      { isTrunk: true, isCurrent: false, expectedAllowed: false, expectedReason: 'is-trunk' },
+      { isTrunk: false, isCurrent: true, expectedAllowed: false, expectedReason: 'is-checked-out' },
+      { isTrunk: true, isCurrent: true, expectedAllowed: false, expectedReason: 'is-trunk' }
+    ]
+
+    it.each(testCases)(
+      'isTrunk=$isTrunk, isCurrent=$isCurrent => allowed=$expectedAllowed',
+      ({ isTrunk, isCurrent, expectedAllowed, expectedReason }) => {
+        const result = getDeleteBranchPermission({ isTrunk, isCurrent })
+        expect(result.allowed).toBe(expectedAllowed)
+        if (!result.allowed && expectedReason) {
+          expect(result.reason).toBe(expectedReason)
+        }
+      }
+    )
+  })
+
+  describe('deniedReason messages', () => {
+    it('includes deniedReason directly in result for denied permissions', () => {
+      const trunkResult = getDeleteBranchPermission({ isTrunk: true, isCurrent: false })
+      expect(trunkResult.deniedReason).toBe('Cannot delete trunk')
+
+      const currentResult = getDeleteBranchPermission({ isTrunk: false, isCurrent: true })
+      expect(currentResult.deniedReason).toBe('Cannot delete the checked out branch')
+    })
+
+    it('includes undefined deniedReason for allowed permissions', () => {
+      const result = getDeleteBranchPermission({ isTrunk: false, isCurrent: false })
+      expect(result.deniedReason).toBeUndefined()
+    })
+
+    it('messages are non-empty strings when denied', () => {
+      const trunkResult = getDeleteBranchPermission({ isTrunk: true, isCurrent: false })
+      const currentResult = getDeleteBranchPermission({ isTrunk: false, isCurrent: true })
+
+      expect(trunkResult.deniedReason).toBeTruthy()
+      expect(typeof trunkResult.deniedReason).toBe('string')
+      expect(trunkResult.deniedReason!.length).toBeGreaterThan(0)
+
+      expect(currentResult.deniedReason).toBeTruthy()
+      expect(typeof currentResult.deniedReason).toBe('string')
+      expect(currentResult.deniedReason!.length).toBeGreaterThan(0)
+    })
+
+    it('messages are distinct for different reasons', () => {
+      const trunkResult = getDeleteBranchPermission({ isTrunk: true, isCurrent: false })
+      const currentResult = getDeleteBranchPermission({ isTrunk: false, isCurrent: true })
+
+      expect(trunkResult.deniedReason).not.toBe(currentResult.deniedReason)
+    })
+  })
+
+  describe('type safety', () => {
+    it('allowed result has correct type shape', () => {
+      const result: DeleteBranchPermission = getDeleteBranchPermission({
+        isTrunk: false,
+        isCurrent: false
+      })
+
+      if (result.allowed) {
+        // TypeScript should know deniedReason is undefined here
+        expect(result.deniedReason).toBeUndefined()
+        // @ts-expect-error - reason should not exist on allowed result
+        expect(result.reason).toBeUndefined()
+      }
+    })
+
+    it('denied result has correct type shape', () => {
+      const result: DeleteBranchPermission = getDeleteBranchPermission({
+        isTrunk: true,
+        isCurrent: false
+      })
+
+      if (!result.allowed) {
+        // TypeScript should know these exist here
+        expect(result.reason).toBeDefined()
+        expect(result.deniedReason).toBeDefined()
+      }
+    })
+  })
+})

--- a/src/shared/permissions/delete-branch.ts
+++ b/src/shared/permissions/delete-branch.ts
@@ -1,0 +1,62 @@
+/**
+ * Permission logic for deleting branches.
+ *
+ * This module is used by:
+ * - Frontend: to determine if the delete option is enabled and show appropriate tooltip
+ * - Backend (BranchOperation): to validate before executing the operation
+ * - MCP Server (future): to validate and return meaningful errors to AI agents
+ */
+
+export type DeleteBranchDeniedReason = 'is-trunk' | 'is-checked-out'
+
+const DENIED_REASON_MESSAGES: Record<DeleteBranchDeniedReason, string> = {
+  'is-trunk': 'Cannot delete trunk',
+  'is-checked-out': 'Cannot delete the checked out branch'
+}
+
+/**
+ * Result of a delete branch permission check.
+ */
+export type DeleteBranchPermission =
+  | { allowed: true; deniedReason: undefined }
+  | { allowed: false; reason: DeleteBranchDeniedReason; deniedReason: string }
+
+/**
+ * Input state for checking delete branch permission.
+ */
+export interface DeleteBranchPermissionInput {
+  /** Whether this is a trunk branch (main, master, etc.) */
+  isTrunk: boolean
+  /** Whether this branch is currently checked out */
+  isCurrent: boolean
+}
+
+/**
+ * Determines whether a branch can be deleted.
+ *
+ * Rules:
+ * - Trunk branches cannot be deleted (they are protected)
+ * - The currently checked out branch cannot be deleted (Git limitation)
+ *
+ * @returns Permission result with `allowed` boolean and `deniedReason` message (if denied).
+ */
+export function getDeleteBranchPermission({
+  isTrunk,
+  isCurrent
+}: DeleteBranchPermissionInput): DeleteBranchPermission {
+  if (isTrunk) {
+    return {
+      allowed: false,
+      reason: 'is-trunk',
+      deniedReason: DENIED_REASON_MESSAGES['is-trunk']
+    }
+  }
+  if (isCurrent) {
+    return {
+      allowed: false,
+      reason: 'is-checked-out',
+      deniedReason: DENIED_REASON_MESSAGES['is-checked-out']
+    }
+  }
+  return { allowed: true, deniedReason: undefined }
+}

--- a/src/shared/permissions/index.ts
+++ b/src/shared/permissions/index.ts
@@ -1,0 +1,6 @@
+export {
+  getDeleteBranchPermission,
+  type DeleteBranchDeniedReason,
+  type DeleteBranchPermission,
+  type DeleteBranchPermissionInput
+} from './delete-branch'

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -85,8 +85,6 @@ export type UiBranch = {
 
   /** True if this branch can be renamed. False for remote and trunk branches. */
   canRename: boolean
-  /** True if this branch can be deleted. False for current and trunk branches. */
-  canDelete: boolean
   /** True if this branch can be folded into its parent. False for remote and trunk branches. */
   canFold: boolean
   /** True if a new worktree can be created for this branch. False for remote and trunk branches. */

--- a/src/web/components/BranchBadge.tsx
+++ b/src/web/components/BranchBadge.tsx
@@ -1,5 +1,6 @@
+import { getDeleteBranchPermission } from '@shared/permissions'
 import type { SquashPreview, UiBranch } from '@shared/types'
-import React, { memo, useCallback, useState } from 'react'
+import React, { memo, useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useUiStateContext } from '../contexts/UiStateContext'
 import { ContextMenu, ContextMenuItem, ContextMenuSeparator } from './ContextMenu'
@@ -139,6 +140,11 @@ export const BranchBadge = memo(function BranchBadge({
   // Show "Open in..." options if we have an openable path
   const canOpen = openablePath != null
 
+  const deletePermission = useMemo(
+    () => getDeleteBranchPermission({ isTrunk: data.isTrunk, isCurrent: data.isCurrent }),
+    [data.isTrunk, data.isCurrent]
+  )
+
   return (
     <>
       <ContextMenu
@@ -157,8 +163,14 @@ export const BranchBadge = memo(function BranchBadge({
             {data.canRename && (
               <ContextMenuItem onClick={handleRename}>Rename branch</ContextMenuItem>
             )}
-            {data.canDelete && (
-              <ContextMenuItem onClick={handleDelete}>Delete branch</ContextMenuItem>
+            {!data.isRemote && (
+              <ContextMenuItem
+                onClick={handleDelete}
+                disabled={!deletePermission.allowed}
+                disabledReason={deletePermission.deniedReason}
+              >
+                Delete branch
+              </ContextMenuItem>
             )}
             {data.canFold && (
               <ContextMenuItem onClick={handleOpenFoldDialog} disabled={isLoadingFoldPreview}>

--- a/src/web/utils/__tests__/enrich-stack-with-forge.test.ts
+++ b/src/web/utils/__tests__/enrich-stack-with-forge.test.ts
@@ -15,7 +15,6 @@ const createBranch = (overrides: Partial<UiBranch> = {}): UiBranch => {
     isRemote,
     isTrunk,
     canRename: !isRemote && !isTrunk,
-    canDelete: !isCurrent && !isTrunk,
     canFold: !isRemote && !isTrunk,
     canCreateWorktree: !isRemote && !isTrunk,
     ...overrides

--- a/src/web/utils/__tests__/get-merged-branch-to-cleanup.test.ts
+++ b/src/web/utils/__tests__/get-merged-branch-to-cleanup.test.ts
@@ -15,7 +15,6 @@ const createBranch = (overrides: Partial<UiBranch> = {}): UiBranch => {
     isMerged: false,
     // Compute permissions based on state (same logic as backend)
     canRename: !isRemote && !isTrunk,
-    canDelete: !isCurrent && !isTrunk,
     canFold: !isRemote && !isTrunk,
     canCreateWorktree: !isRemote && !isTrunk,
     ...overrides


### PR DESCRIPTION
## Summary

- Show "Delete branch" context menu option as disabled (with tooltip) instead of hidden when the branch can't be deleted
- Add `shared/permissions/delete-branch.ts` - pure permission logic usable by both frontend and backend
- Add `docs/PERMISSION_MIGRATION.md` documenting the architecture for migrating remaining permission flags

**Before:** "Delete branch" was hidden for current/trunk branches
**After:** "Delete branch" shows disabled with tooltip explaining why ("Cannot delete the checked out branch" or "Cannot delete trunk")

## Architecture

The permission logic now lives in `shared/permissions/` following the existing layered architecture:

```
shared/permissions/     → Pure permission functions (used by web/ and node/)
    ↓
web/components/        → Uses for UI disabled state + tooltip
node/operations/       → Uses for validation before execution
```

This enables future MCP server integration to return meaningful errors to AI agents.

## Test plan

- [x] Typecheck passes
- [x] All tests pass (589/589)
- [x] Lint passes (only pre-existing warnings in other files)
- [x] Manual test: Right-click current branch → "Delete branch" shows disabled with tooltip
- [x] Manual test: Right-click trunk branch → "Delete branch" shows disabled with tooltip
- [x] Manual test: Right-click other branch → "Delete branch" is enabled and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)