### PR TITLE
fix: prevent lock queue chain breakage on error

### DIFF
--- a/docs/timeout-implementation.md
+++ b/docs/timeout-implementation.md
@@ -1,0 +1,467 @@
+# Timeout Implementation Design Document
+
+## Problem Statement
+
+Currently, async operations in Teapot have no timeout protection. If a git operation hangs (network issues, large repo, corrupted state), the entire operation blocks indefinitely, causing:
+
+1. **"Reply was never sent" errors** - IPC handlers never return
+2. **UI freezes** - Users see infinite loading spinners
+3. **Resource exhaustion** - Blocked operations hold locks forever
+4. **Poor user experience** - No way to cancel or recover
+
+## Goals
+
+1. Add configurable timeouts to all async operations
+2. Provide clear error messages when timeouts occur
+3. Support cancellation for long-running operations
+4. Maintain backwards compatibility
+5. Minimize code changes while maximizing coverage
+
+## Design
+
+### Core Utility: `withTimeout`
+
+A generic wrapper that races any promise against a timeout:
+
+```typescript
+// src/node/utils/timeout.ts
+
+export class TimeoutError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly timeoutMs: number
+  ) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        reject(new TimeoutError(
+          `${operation} timed out after ${timeoutMs}ms`,
+          operation,
+          timeoutMs
+        ))
+      }, timeoutMs)
+      // Don't block Node.js from exiting
+      timer.unref?.()
+    })
+  ])
+}
+```
+
+### Configuration: Timeout Presets
+
+Centralized timeout configuration for different operation types:
+
+```typescript
+// src/node/config/timeouts.ts
+
+export const Timeouts = {
+  // Git operations
+  GIT_FETCH: 60_000,         // 60s - network operation
+  GIT_REBASE: 120_000,       // 2min - can be slow for large branches
+  GIT_CHECKOUT: 30_000,      // 30s - usually fast
+  GIT_STATUS: 10_000,        // 10s - should be quick
+  GIT_LOG: 30_000,           // 30s - depends on history size
+
+  // Lock acquisition
+  LOCK_ACQUIRE: 30_000,      // 30s - waiting for other operations
+  FILE_LOCK: 5_000,          // 5s - file system lock
+
+  // Context operations
+  CONTEXT_ACQUIRE: 60_000,   // 60s - may create worktree
+  WORKTREE_CREATE: 30_000,   // 30s - git worktree add
+  WORKTREE_REMOVE: 10_000,   // 10s - git worktree remove
+
+  // IPC operations
+  IPC_DEFAULT: 120_000,      // 2min - default for IPC handlers
+
+  // Forge operations
+  FORGE_API: 30_000,         // 30s - GitHub/GitLab API calls
+} as const
+
+export type TimeoutKey = keyof typeof Timeouts
+
+// Allow runtime configuration override
+const overrides: Partial<typeof Timeouts> = {}
+
+export function getTimeout(key: TimeoutKey): number {
+  return overrides[key] ?? Timeouts[key]
+}
+
+export function setTimeoutOverride(key: TimeoutKey, ms: number): void {
+  overrides[key] = ms
+}
+```
+
+### Integration Points
+
+#### 1. ExecutionContextService
+
+```typescript
+// src/node/services/ExecutionContextService.ts
+
+import { withTimeout } from '../utils/timeout'
+import { getTimeout } from '../config/timeouts'
+
+export class ExecutionContextService {
+  static async acquire(
+    repoPath: string,
+    operation: ExecutionOperation = 'unknown'
+  ): Promise<ExecutionContext> {
+    return withTimeout(
+      this.acquireInternal(repoPath, operation),
+      getTimeout('CONTEXT_ACQUIRE'),
+      `acquire execution context for ${operation}`
+    )
+  }
+
+  private static async acquireLock(repoPath: string): Promise<() => Promise<void>> {
+    const mutex = getRepoMutex(repoPath)
+
+    // Timeout on mutex acquisition
+    const releaseMutex = await withTimeout(
+      mutex.acquire(),
+      getTimeout('LOCK_ACQUIRE'),
+      'acquire repository mutex'
+    )
+
+    try {
+      // Timeout on file lock
+      await withTimeout(
+        this.acquireFileLock(repoPath),
+        getTimeout('FILE_LOCK'),
+        'acquire file lock'
+      )
+      return async () => {
+        await this.releaseFileLock(repoPath)
+        releaseMutex()
+      }
+    } catch (error) {
+      releaseMutex()
+      throw error
+    }
+  }
+}
+```
+
+#### 2. Git Adapter
+
+```typescript
+// src/node/adapters/git/SimpleGitAdapter.ts
+
+import { withTimeout } from '../../utils/timeout'
+import { getTimeout } from '../../config/timeouts'
+
+export class SimpleGitAdapter implements GitAdapter {
+  async fetch(repoPath: string, remote: string): Promise<void> {
+    return withTimeout(
+      this.git(repoPath).fetch(remote),
+      getTimeout('GIT_FETCH'),
+      `git fetch ${remote}`
+    )
+  }
+
+  async rebase(repoPath: string, options: RebaseOptions): Promise<RebaseResult> {
+    return withTimeout(
+      this.rebaseInternal(repoPath, options),
+      getTimeout('GIT_REBASE'),
+      `git rebase onto ${options.onto}`
+    )
+  }
+
+  async getWorkingTreeStatus(repoPath: string): Promise<WorkingTreeStatus> {
+    return withTimeout(
+      this.statusInternal(repoPath),
+      getTimeout('GIT_STATUS'),
+      'git status'
+    )
+  }
+}
+```
+
+#### 3. IPC Handlers
+
+Wrap all IPC handlers with a default timeout:
+
+```typescript
+// src/node/handlers/wrapHandler.ts
+
+import { withTimeout, TimeoutError } from '../utils/timeout'
+import { getTimeout } from '../config/timeouts'
+
+export function wrapHandler<T extends (...args: any[]) => Promise<any>>(
+  handler: T,
+  operationName: string,
+  timeoutMs?: number
+): T {
+  return (async (...args: Parameters<T>) => {
+    try {
+      return await withTimeout(
+        handler(...args),
+        timeoutMs ?? getTimeout('IPC_DEFAULT'),
+        operationName
+      )
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        // Log timeout for debugging
+        log.error({ err: error, operation: operationName }, 'IPC handler timed out')
+        // Return user-friendly error
+        throw new Error(`Operation timed out: ${operationName}. Please try again.`)
+      }
+      throw error
+    }
+  }) as T
+}
+
+// Usage in handlers registration:
+ipcMain.handle(
+  IPC_CHANNELS.confirmRebaseIntent,
+  wrapHandler(confirmRebaseIntent, 'confirmRebaseIntent')
+)
+```
+
+#### 4. ContextScope Enhancement
+
+```typescript
+// src/node/services/ContextScope.ts
+
+export class ContextScope implements Disposable {
+  private timeoutId?: NodeJS.Timeout
+
+  static async acquire(
+    repoPath: string,
+    operation: ExecutionOperation = 'unknown',
+    options: { timeoutMs?: number } = {}
+  ): Promise<ContextScope> {
+    const timeoutMs = options.timeoutMs ?? getTimeout('CONTEXT_ACQUIRE')
+
+    const context = await withTimeout(
+      ExecutionContextService.acquire(repoPath, operation),
+      timeoutMs,
+      `acquire context for ${operation}`
+    )
+
+    return new ContextScope(repoPath, context)
+  }
+
+  /**
+   * Set a maximum lifetime for this context.
+   * If exceeded, the context will be automatically released.
+   */
+  setMaxLifetime(ms: number, onTimeout?: () => void): void {
+    this.timeoutId = setTimeout(() => {
+      log.warn(`Context lifetime exceeded (${ms}ms), auto-releasing`)
+      onTimeout?.()
+      void this.disposeAsync()
+    }, ms)
+    this.timeoutId.unref?.()
+  }
+
+  async disposeAsync(): Promise<void> {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId)
+    }
+    // ... existing cleanup
+  }
+}
+```
+
+### Cancellation Support
+
+For operations that support cancellation:
+
+```typescript
+// src/node/utils/cancellation.ts
+
+export function withCancellation<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (signal?.aborted) {
+    return Promise.reject(new Error('Operation cancelled'))
+  }
+
+  return new Promise((resolve, reject) => {
+    const abortHandler = () => reject(new Error('Operation cancelled'))
+    signal?.addEventListener('abort', abortHandler, { once: true })
+
+    fn(signal ?? new AbortController().signal)
+      .then(resolve)
+      .catch(reject)
+      .finally(() => signal?.removeEventListener('abort', abortHandler))
+  })
+}
+
+// Combined timeout + cancellation
+export function withTimeoutAndCancellation<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  operation: string,
+  externalSignal?: AbortSignal
+): Promise<T> {
+  const controller = new AbortController()
+
+  // Link external signal
+  if (externalSignal) {
+    externalSignal.addEventListener('abort', () => controller.abort(), { once: true })
+  }
+
+  const timeoutId = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
+  timeoutId.unref?.()
+
+  return fn(controller.signal)
+    .finally(() => clearTimeout(timeoutId))
+    .catch(error => {
+      if (controller.signal.aborted && !externalSignal?.aborted) {
+        throw new TimeoutError(`${operation} timed out after ${timeoutMs}ms`, operation, timeoutMs)
+      }
+      throw error
+    })
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure (Low Risk)
+1. Add `withTimeout` utility
+2. Add `TimeoutError` class
+3. Add timeout configuration module
+4. Add tests for timeout utilities
+
+### Phase 2: Lock Acquisition (Medium Risk)
+1. Add timeout to `acquireLock` in ExecutionContextService
+2. Add timeout to file lock acquisition
+3. Update tests
+
+### Phase 3: Git Operations (Medium Risk)
+1. Wrap git fetch with timeout
+2. Wrap git rebase with timeout
+3. Wrap git status with timeout
+4. Update integration tests
+
+### Phase 4: IPC Handlers (Low Risk)
+1. Create `wrapHandler` utility
+2. Apply to all IPC handlers
+3. Add timeout logging
+
+### Phase 5: Cancellation (Higher Risk)
+1. Add AbortController support
+2. Wire through to git operations where possible
+3. Add UI cancellation buttons
+
+## Testing Strategy
+
+### Unit Tests
+
+```typescript
+describe('withTimeout', () => {
+  it('resolves when promise completes before timeout', async () => {
+    const result = await withTimeout(
+      Promise.resolve('success'),
+      1000,
+      'test'
+    )
+    expect(result).toBe('success')
+  })
+
+  it('rejects with TimeoutError when timeout exceeded', async () => {
+    await expect(
+      withTimeout(
+        new Promise(() => {}), // never resolves
+        100,
+        'test operation'
+      )
+    ).rejects.toThrow(TimeoutError)
+  })
+
+  it('includes operation name in error', async () => {
+    try {
+      await withTimeout(new Promise(() => {}), 100, 'my operation')
+    } catch (e) {
+      expect(e.operation).toBe('my operation')
+      expect(e.timeoutMs).toBe(100)
+    }
+  })
+})
+```
+
+### Integration Tests
+
+```typescript
+describe('ExecutionContextService with timeouts', () => {
+  it('times out when lock cannot be acquired', async () => {
+    // Hold the lock
+    const scope1 = await ContextScope.acquire(repoPath)
+
+    // Try to acquire with short timeout
+    await expect(
+      ContextScope.acquire(repoPath, 'rebase', { timeoutMs: 100 })
+    ).rejects.toThrow(TimeoutError)
+
+    await scope1.disposeAsync()
+  })
+})
+```
+
+## Monitoring & Observability
+
+### Logging
+
+```typescript
+// Log all timeout occurrences
+log.error({
+  err: error,
+  operation,
+  timeoutMs,
+  component: 'timeout'
+}, 'Operation timed out')
+```
+
+### Metrics (Future)
+
+Consider adding metrics for:
+- Operation duration distribution
+- Timeout frequency by operation type
+- Lock wait times
+
+## Rollout Strategy
+
+1. **Feature flag**: Add `TEAPOT_ENABLE_TIMEOUTS` env var
+2. **Gradual rollout**: Start with long timeouts, reduce based on telemetry
+3. **Monitoring**: Track timeout occurrences in logs
+4. **User feedback**: Surface timeout errors clearly in UI
+
+## Open Questions
+
+1. **What should happen to in-flight git operations when timeout occurs?**
+   - Git operations can't always be cleanly cancelled
+   - May need to wait for git to finish even after timeout
+   - Consider marking context as "abandoned" vs "clean"
+
+2. **Should we expose timeout configuration to users?**
+   - Power users might want to adjust for slow networks
+   - Could add to Settings UI
+
+3. **How to handle partial completion?**
+   - Rebase might timeout mid-stack
+   - Need to ensure consistent state
+   - Consider checkpointing
+
+## References
+
+- [async-mutex documentation](https://www.npmjs.com/package/async-mutex)
+- [AbortController MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+- [Node.js Timers](https://nodejs.org/api/timers.html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "clsx": "^2.1.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.3.9",
@@ -1397,6 +1398,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1803,6 +1842,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1844,6 +1906,107 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1944,11 +2107,100 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1973,6 +2225,71 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",


### PR DESCRIPTION
## Summary

- Fix edge case where promise chain mutex could hang all subsequent 
  operations if one operation throws an error
- Add try/catch around file lock acquisition to release queue slot on failure

## Problem

The `acquireLock()` method uses a promise chain for serializing access. 
If an operation threw after acquiring its spot in the queue but before 
calling the release function, the chain would break and all subsequent 
operations would wait forever.

## Solution

1. Add `.catch(() => {})` to prevent rejected promises from breaking the chain
2. Wrap `acquireFileLock()` in try/catch to release queue slot on failure

## Test plan

- [x] All 629 existing tests pass
- [x] Type checking passes
