### PR TITLE
fix: delete remote branch when deleting branch with closed PR

### DIFF
--- a/src/node/operations/BranchOperation.ts
+++ b/src/node/operations/BranchOperation.ts
@@ -163,6 +163,25 @@ export class BranchOperation {
 
     await this.closePullRequestForBranch(repoPath, branchName)
 
+    // Delete remote branch if it exists
+    try {
+      await gitForgeService.deleteRemoteBranch(repoPath, branchName)
+      log.info(`[BranchOperation.delete] Deleted remote branch: ${branchName}`)
+    } catch (error) {
+      log.warn(
+        `[BranchOperation.delete] Failed to delete remote branch (continuing with local): ${branchName}`,
+        error
+      )
+    }
+
+    // Delete remote-tracking reference
+    try {
+      await git.deleteRemoteTrackingBranch(repoPath, 'origin', branchName)
+      log.info(`[BranchOperation.delete] Deleted remote-tracking ref: origin/${branchName}`)
+    } catch {
+      // Ignore - the remote-tracking ref may not exist
+    }
+
     await git.deleteBranch(repoPath, branchName)
     log.info(`[BranchOperation.delete] Deleted local branch: ${branchName}`)
   }


### PR DESCRIPTION
## Summary

When deleting a branch that has a closed PR, the remote branch on GitHub was not being deleted. The `delete()` method only:
1. Closed the PR (if open)
2. Deleted the local branch

This fix adds remote cleanup to match what `cleanup()` already does:
1. Close the PR (if open)
2. **Delete the remote branch via GitHub API** ← new
3. **Delete the local remote-tracking reference** ← new
4. Delete the local branch

Failures are handled gracefully - if remote deletion fails (e.g., no PAT configured, network error), local cleanup still proceeds.

## Test plan

- [x] Added test: `should delete local branch and attempt remote deletion`
- [x] Added test: `should delete remote-tracking ref when deleting branch`
- [x] Added test: `should succeed even if remote deletion fails`
- [x] All 37 existing BranchOperation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)