### PR TITLE
fix: show error dialog when branch deletion or cleanup fails

### DIFF
--- a/src/node/handlers/repo.ts
+++ b/src/node/handlers/repo.ts
@@ -315,16 +315,44 @@ const deleteBranchHandler: IpcHandlerOf<'deleteBranch'> = async (
   _event,
   { repoPath, branchName }
 ) => {
-  await BranchOperation.delete(repoPath, branchName)
-  return UiStateOperation.getUiState(repoPath)
+  try {
+    await BranchOperation.delete(repoPath, branchName)
+    return UiStateOperation.getUiState(repoPath)
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    await dialog.showMessageBox({
+      type: 'error',
+      title: 'Failed to Delete Branch',
+      message: `Unable to delete branch '${branchName}'`,
+      detail: errorMessage,
+      buttons: ['OK']
+    })
+
+    throw error
+  }
 }
 
 const cleanupBranchHandler: IpcHandlerOf<'cleanupBranch'> = async (
   _event,
   { repoPath, branchName }
 ) => {
-  await BranchOperation.cleanup(repoPath, branchName)
-  return UiStateOperation.getUiState(repoPath)
+  try {
+    await BranchOperation.cleanup(repoPath, branchName)
+    return UiStateOperation.getUiState(repoPath)
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    await dialog.showMessageBox({
+      type: 'error',
+      title: 'Failed to Cleanup Branch',
+      message: `Unable to cleanup branch '${branchName}'`,
+      detail: errorMessage,
+      buttons: ['OK']
+    })
+
+    throw error
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add error handling to `deleteBranchHandler` to show a dialog when branch deletion fails
- Add error handling to `cleanupBranchHandler` for consistency

Previously these handlers had no error handling, causing errors to fail silently without any user feedback. Now when an operation fails (e.g., worktree removal fails with "Directory not empty"), the user will see a dialog with the error details.

## Test plan
- [ ] Attempt to delete a branch where the worktree directory is not empty or otherwise blocked
- [ ] Verify an error dialog appears with "Failed to Delete Branch" and the error message
- [ ] Attempt cleanup on a branch that fails similarly
- [ ] Verify an error dialog appears with "Failed to Cleanup Branch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)