### PR TITLE
feat: add debug logging for troubleshooting stuck states

### DIFF
--- a/src/node/adapters/forge/GitForgeClient.ts
+++ b/src/node/adapters/forge/GitForgeClient.ts
@@ -226,7 +226,7 @@ export class GitForgeClient {
     this.pendingCacheWrite = setTimeout(() => {
       if (this.repoPath && this.state.pullRequests.length > 0) {
         configStore.setCachedForgeState(this.repoPath, this.state)
-        log.info(`[GitForgeClient] Persisted cache for ${this.repoPath}`)
+        log.debug(`[GitForgeClient] Persisted cache for ${this.repoPath}`)
       }
       this.pendingCacheWrite = null
     }, this.DEBOUNCE_WRITE_MS)

--- a/src/node/adapters/forge/github/GitHubAdapter.ts
+++ b/src/node/adapters/forge/github/GitHubAdapter.ts
@@ -329,7 +329,14 @@ export class GitHubAdapter implements GitForgeAdapter {
     for (let i = 0; i < openPrs.length; i += CONCURRENCY) {
       const batch = openPrs.slice(i, i + CONCURRENCY)
       const results = await Promise.all(
-        batch.map((pr) => this.fetchPrDetailsWithChecks(pr.number).catch(() => null))
+        batch.map((pr) =>
+          this.fetchPrDetailsWithChecks(pr.number).catch((error) => {
+            log.debug(`[GitHubAdapter] fetchPrDetailsWithChecks() failed for PR #${pr.number}`, {
+              message: error instanceof Error ? error.message : String(error)
+            })
+            return null
+          })
+        )
       )
       batch.forEach((pr, idx) => {
         const result = results[idx]

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -3,9 +3,10 @@ import { app, BrowserWindow, shell } from 'electron'
 import electronUpdater from 'electron-updater'
 import { join } from 'path'
 import icon from '../../resources/icon.png?asset'
-import { log } from '../shared/logger'
+import { initFileLogging, log } from '../shared/logger'
 import { IPC_EVENTS } from '../shared/types'
 import { registerHandlers } from './handlers'
+import { configStore } from './store'
 
 function setupAutoUpdater(): void {
   const { autoUpdater } = electronUpdater
@@ -94,7 +95,7 @@ function createWindow(): void {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   // Set app user model id for windows
   electronApp.setAppUserModelId('com.electron')
 
@@ -107,6 +108,12 @@ app.whenReady().then(() => {
 
   // Register all IPC handlers
   registerHandlers()
+
+  // Initialize file logging for debug mode
+  await initFileLogging(
+    () => configStore.getDebugLoggingEnabled(),
+    () => configStore.getSelectedRepoPath()
+  )
 
   createWindow()
 

--- a/src/node/operations/BranchOperation.ts
+++ b/src/node/operations/BranchOperation.ts
@@ -119,8 +119,14 @@ export class BranchOperation {
     try {
       await git.deleteRemoteTrackingBranch(repoPath, 'origin', branchName)
       log.info(`[BranchOperation.cleanup] Deleted remote-tracking ref: origin/${branchName}`)
-    } catch {
-      // Ignore - the remote-tracking ref may not exist
+    } catch (error) {
+      // Expected if the remote-tracking ref doesn't exist
+      log.debug(
+        `[BranchOperation.cleanup] Remote-tracking ref cleanup skipped: origin/${branchName}`,
+        {
+          message: error instanceof Error ? error.message : String(error)
+        }
+      )
     }
 
     await git.deleteBranch(repoPath, branchName)
@@ -178,8 +184,14 @@ export class BranchOperation {
     try {
       await git.deleteRemoteTrackingBranch(repoPath, 'origin', branchName)
       log.info(`[BranchOperation.delete] Deleted remote-tracking ref: origin/${branchName}`)
-    } catch {
-      // Ignore - the remote-tracking ref may not exist
+    } catch (error) {
+      // Expected if the remote-tracking ref doesn't exist
+      log.debug(
+        `[BranchOperation.delete] Remote-tracking ref cleanup skipped: origin/${branchName}`,
+        {
+          message: error instanceof Error ? error.message : String(error)
+        }
+      )
     }
 
     await git.deleteBranch(repoPath, branchName)

--- a/src/node/services/TransactionService.ts
+++ b/src/node/services/TransactionService.ts
@@ -283,7 +283,16 @@ export class TransactionService {
       const filePath = this.getIntentFilePath(repoPath)
       const content = await fs.promises.readFile(filePath, 'utf-8')
       return JSON.parse(content) as TransactionIntent
-    } catch {
+    } catch (error) {
+      // ENOENT is expected (no intent file), but parse errors should be logged
+      const errCode = (error as NodeJS.ErrnoException).code
+      if (errCode !== 'ENOENT') {
+        log.warn('[TransactionService] loadIntent() failed to parse intent file', {
+          repoPath,
+          errCode,
+          message: error instanceof Error ? error.message : String(error)
+        })
+      }
       return null
     }
   }

--- a/src/node/store.ts
+++ b/src/node/store.ts
@@ -27,6 +27,7 @@ interface StoreSchema {
   preferredEditor?: string
   mergeStrategy?: MergeStrategy
   lastClonePath?: string
+  debugLoggingEnabled?: boolean
   rebaseSessions: Record<string, StoredRebaseSession>
   forgeStateCache: Record<string, CachedForgeState>
 }
@@ -84,6 +85,26 @@ export class ConfigStore {
 
   setLastClonePath(path: string): void {
     this.store.set('lastClonePath', path)
+  }
+
+  // Debug logging methods
+
+  getDebugLoggingEnabled(): boolean {
+    return this.store.get('debugLoggingEnabled', false)
+  }
+
+  setDebugLoggingEnabled(enabled: boolean): void {
+    this.store.set('debugLoggingEnabled', enabled)
+  }
+
+  /**
+   * Get the path of the currently selected repo.
+   * Returns null if no repo is selected.
+   */
+  getSelectedRepoPath(): string | null {
+    const repos = this.getLocalRepos()
+    const selected = repos.find((r) => r.isSelected)
+    return selected?.path ?? null
   }
 
   private setRepos(repos: LocalRepo[]): void {

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -130,6 +130,9 @@ export const IPC_CHANNELS = {
   // Settings
   getPreferredEditor: 'getPreferredEditor',
   setPreferredEditor: 'setPreferredEditor',
+  getDebugLogging: 'getDebugLogging',
+  setDebugLogging: 'setDebugLogging',
+  showDebugLogFile: 'showDebugLogFile',
   // Worktree
   getActiveWorktree: 'getActiveWorktree',
   switchWorktree: 'switchWorktree',
@@ -283,6 +286,18 @@ export interface IpcContract {
   [IPC_CHANNELS.setPreferredEditor]: {
     request: { editor: string }
     response: void
+  }
+  [IPC_CHANNELS.getDebugLogging]: {
+    request: void
+    response: boolean
+  }
+  [IPC_CHANNELS.setDebugLogging]: {
+    request: { enabled: boolean }
+    response: void
+  }
+  [IPC_CHANNELS.showDebugLogFile]: {
+    request: void
+    response: { success: boolean; error?: string }
   }
   [IPC_CHANNELS.getMergeStrategy]: {
     request: void

--- a/src/web/components/Dialog.tsx
+++ b/src/web/components/Dialog.tsx
@@ -59,6 +59,7 @@ export function DialogContent({
       className={cn(
         'bg-background text-foreground border-border animate-in fade-in slide-in-from-top-2 fixed top-[50%] left-[50%]',
         'z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
+        'max-h-[85vh] overflow-y-auto',
         'gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
         className
       )}


### PR DESCRIPTION
## Summary

- Add opt-in debug logging to help diagnose issues like stuck "Git Rebasing" states
- Logs are written to `.git/teapot-debug.log` (per-repo, cleared on each Teapot startup)
- Add "Show log file" button in Settings to quickly reveal the log in Finder/Explorer
- Add error logging to previously silent catch blocks for better visibility into failures

## What's logged

When enabled, captures:
- Rebase execution flow (context acquisition, session state changes)
- Session management (load, save, clear operations)
- Execution context acquisition and release
- Errors that were previously swallowed silently

## Test plan

- [x] Open Settings and enable "Debug Logging"
- [x] Perform some operations (switch branches, start a rebase, etc.)
- [x] Click "Show log file" to verify logs are being written
- [x] Disable debug logging and verify no new logs are written
- [x] Resize window small and verify settings dialog scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)