### PR TITLE
feat: improve file logging with level selection and performance

### DIFF
--- a/src/node/handlers/local-state.ts
+++ b/src/node/handlers/local-state.ts
@@ -52,12 +52,12 @@ const setPreferredEditorHandler: IpcHandlerOf<'setPreferredEditor'> = (_event, {
   configStore.setPreferredEditor(editor)
 }
 
-const getDebugLoggingHandler: IpcHandlerOf<'getDebugLogging'> = () => {
-  return configStore.getDebugLoggingEnabled()
+const getFileLogLevelHandler: IpcHandlerOf<'getFileLogLevel'> = () => {
+  return configStore.getFileLogLevel()
 }
 
-const setDebugLoggingHandler: IpcHandlerOf<'setDebugLogging'> = (_event, { enabled }) => {
-  configStore.setDebugLoggingEnabled(enabled)
+const setFileLogLevelHandler: IpcHandlerOf<'setFileLogLevel'> = (_event, { level }) => {
+  configStore.setFileLogLevel(level)
 }
 
 const showDebugLogFileHandler: IpcHandlerOf<'showDebugLogFile'> = () => {
@@ -129,8 +129,8 @@ export function registerLocalStateHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.setGithubPat, setGithubPatHandler)
   ipcMain.handle(IPC_CHANNELS.getPreferredEditor, getPreferredEditorHandler)
   ipcMain.handle(IPC_CHANNELS.setPreferredEditor, setPreferredEditorHandler)
-  ipcMain.handle(IPC_CHANNELS.getDebugLogging, getDebugLoggingHandler)
-  ipcMain.handle(IPC_CHANNELS.setDebugLogging, setDebugLoggingHandler)
+  ipcMain.handle(IPC_CHANNELS.getFileLogLevel, getFileLogLevelHandler)
+  ipcMain.handle(IPC_CHANNELS.setFileLogLevel, setFileLogLevelHandler)
   ipcMain.handle(IPC_CHANNELS.showDebugLogFile, showDebugLogFileHandler)
   ipcMain.handle(IPC_CHANNELS.getMergeStrategy, getMergeStrategyHandler)
   ipcMain.handle(IPC_CHANNELS.setMergeStrategy, setMergeStrategyHandler)

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -109,9 +109,9 @@ app.whenReady().then(async () => {
   // Register all IPC handlers
   registerHandlers()
 
-  // Initialize file logging for debug mode
+  // Initialize file logging with level-based filtering
   await initFileLogging(
-    () => configStore.getDebugLoggingEnabled(),
+    () => configStore.getFileLogLevel(),
     () => configStore.getSelectedRepoPath()
   )
 

--- a/src/node/services/ExecutionContextService.ts
+++ b/src/node/services/ExecutionContextService.ts
@@ -254,7 +254,9 @@ export class ExecutionContextService {
   ): Promise<ExecutionContext> {
     // Support both legacy (string) and new (options object) calling conventions
     const options =
-      typeof operationOrOptions === 'string' ? { operation: operationOrOptions } : operationOrOptions
+      typeof operationOrOptions === 'string'
+        ? { operation: operationOrOptions }
+        : operationOrOptions
     const operation = options.operation ?? 'unknown'
     const targetBranch = options.targetBranch
 

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -5,6 +5,12 @@ import type { BranchChoice, SquashPreview, SquashResult } from './squash'
 import type { LocalRepo, UiState } from './ui'
 
 /**
+ * File logging level options for the settings UI.
+ * Controls what gets written to the debug log file.
+ */
+export type FileLogLevel = 'off' | 'standard' | 'verbose' | 'everything'
+
+/**
  * Response type for rebase operations (continue, abort, skip)
  */
 export type RebaseOperationResponse = {
@@ -130,8 +136,8 @@ export const IPC_CHANNELS = {
   // Settings
   getPreferredEditor: 'getPreferredEditor',
   setPreferredEditor: 'setPreferredEditor',
-  getDebugLogging: 'getDebugLogging',
-  setDebugLogging: 'setDebugLogging',
+  getFileLogLevel: 'getFileLogLevel',
+  setFileLogLevel: 'setFileLogLevel',
   showDebugLogFile: 'showDebugLogFile',
   // Worktree
   getActiveWorktree: 'getActiveWorktree',
@@ -287,12 +293,12 @@ export interface IpcContract {
     request: { editor: string }
     response: void
   }
-  [IPC_CHANNELS.getDebugLogging]: {
+  [IPC_CHANNELS.getFileLogLevel]: {
     request: void
-    response: boolean
+    response: FileLogLevel
   }
-  [IPC_CHANNELS.setDebugLogging]: {
-    request: { enabled: boolean }
+  [IPC_CHANNELS.setFileLogLevel]: {
+    request: { level: FileLogLevel }
     response: void
   }
   [IPC_CHANNELS.showDebugLogFile]: {


### PR DESCRIPTION
## Summary

Improves the debug logging system to reduce noise in large repos and give users control over log verbosity:

- **Log level selection**: Replace binary on/off toggle with granular levels (Off, Standard, Verbose, All)
- **Async buffered writes**: Buffer logs and flush periodically to avoid blocking the main process
- **Log rotation**: Automatically rotate logs at 10MB, keeping up to 3 rotated files
- **Reduced noise**: Skip START timing logs in file output (only log END with duration)
- **Process safety**: Flush buffer on exit to prevent data loss
- **Settings UI**: Segmented control for selecting log level with descriptions

### Log Levels

| Level | What's logged |
|-------|--------------|
| Off | Nothing written to disk |
| Standard | Info, warnings, errors |
| Verbose | Standard + debug messages |
| All | Everything including performance traces |

### Migration

Automatically migrates legacy `debugLoggingEnabled: true` to `fileLogLevel: 'verbose'` on first read.

## Test plan

- [x] Open Settings dialog and verify Debug Logging section appears
- [x] Toggle between log levels and verify description updates
- [x] Click the log file path to open it in Finder
- [x] With logging enabled, perform actions and verify logs appear in file
- [x] Verify START logs are not written (only END with duration)
- [x] Test with large repo to verify no UI blocking during heavy logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)