### PR TITLE
fix: sync trunk without temporary worktrees

### DIFF
--- a/src/node/adapters/git/SimpleGitAdapter.ts
+++ b/src/node/adapters/git/SimpleGitAdapter.ts
@@ -419,7 +419,8 @@ export class SimpleGitAdapter implements GitAdapter {
           } else if (line.startsWith('branch ')) {
             // Strip refs/heads/ prefix
             branch = line.slice('branch '.length).replace('refs/heads/', '')
-          } else if (line === 'prunable') {
+          } else if (line.startsWith('prunable')) {
+            // Git outputs "prunable" followed by a reason (e.g., "gitdir file points to non-existent location")
             isStale = true
           }
         }

--- a/src/node/operations/__tests__/WorktreeUtils.test.ts
+++ b/src/node/operations/__tests__/WorktreeUtils.test.ts
@@ -381,7 +381,8 @@ describe('WorktreeUtils', () => {
 
       const result = await isWorktreeStale(repoPath, worktreePath)
       expect(result.isStale).toBe(true)
-      expect(result.reason).toBe('directory_missing')
+      // Git marks worktrees with missing directories as "prunable"
+      expect(result.reason).toBe('marked_prunable')
 
       // Clean up
       execSync('git worktree prune', { cwd: repoPath })
@@ -426,7 +427,8 @@ describe('WorktreeUtils', () => {
       const result = await pruneIfStale(repoPath, worktreePath)
       expect(result.wasStale).toBe(true)
       expect(result.pruned).toBe(true)
-      expect(result.reason).toBe('directory_missing')
+      // Git marks worktrees with missing directories as "prunable"
+      expect(result.reason).toBe('marked_prunable')
 
       // Worktree should be gone from git's list
       const list = execSync('git worktree list --porcelain', {


### PR DESCRIPTION
## Summary

- Refactors `syncTrunk` to use a strategy-based approach that avoids creating temporary worktrees
- Fixes the **detached HEAD bug** where pressing "Pull" while on main with a clean tree would leave the user in detached HEAD state
- Adds proper stale worktree detection and handling

## Changes

### Strategy-based sync approach
- **Direct ref update**: When trunk is not checked out anywhere, uses `git fetch origin main:main` for atomic ref update
- **Merge in worktree**: When trunk is checked out and clean, uses `git merge --ff-only` in that worktree
- **Block with error**: When trunk has uncommitted changes, returns clear error message

### Bug fixes
- Fixed `SimpleGitAdapter` to detect "prunable" status when git outputs the reason suffix (e.g., "prunable gitdir file points to non-existent location")
- Added `git worktree prune` before direct ref update to handle stale worktrees that git still thinks are active

### Files modified
| File | Changes |
|------|---------|
| `src/node/operations/BranchOperation.ts` | Refactored `syncTrunk()`, added helper functions for strategy selection |
| `src/node/adapters/git/SimpleGitAdapter.ts` | Fixed stale worktree detection |
| `src/node/__tests__/operations/BranchOperation.syncTrunk.test.ts` | Added 7 new tests for edge cases |
| `src/node/operations/__tests__/WorktreeUtils.test.ts` | Updated expectations for prunable detection |

## Test plan

- [x] All 709 tests pass
- [x] Manual test: On trunk with clean tree, press Pull → verify main updated, still on main (not detached HEAD)
- [x] Manual test: On feature branch, press Pull → verify main ref updated via direct fetch
- [x] Manual test: From linked worktree, press Pull with main checked out clean elsewhere → verify merge happens in correct worktree
- [x] Manual test: On trunk with dirty tree, press Pull → verify blocked with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)