### PR TITLE
fix: include branchless ancestor commits in rebase operations

### DIFF
--- a/src/node/domain/RebaseIntentBuilder.ts
+++ b/src/node/domain/RebaseIntentBuilder.ts
@@ -46,7 +46,10 @@ export class RebaseIntentBuilder {
       return null
     }
 
-    const branchHeadIndex = StackAnalyzer.buildBranchHeadIndex(repo.branches)
+    // Only include local branches in the index - remote branches don't affect local ownership
+    // This matches the behavior in UiStateBuilder for consistent ownership calculation
+    const localBranches = repo.branches.filter((b) => !b.isRemote)
+    const branchHeadIndex = StackAnalyzer.buildBranchHeadIndex(localBranches)
 
     // Build trunk SHA set once - reused for all ownership calculations
     const trunkBranch = repo.branches.find((b) => b.isTrunk && !b.isRemote)


### PR DESCRIPTION
## Summary
- Fixes issue where branchless ancestor commits were not being rebased along with their branch
- Fixes issue where rebase preview showed ancestor commits being left behind

## Root Causes

### Issue 1: Remote branch filtering mismatch
`UiStateBuilder` excluded remote branches when building `branchHeadIndex` for ownership calculation, but `RebaseIntentBuilder` included ALL branches. This caused:
- UI correctly showing branchless ancestors as owned by the branch
- Rebase logic incorrectly stopping at remote tracking branches

### Issue 2: Preview only moving branch head
`applyIntentTarget` only updated the branch head commit's parent, leaving owned ancestor commits orphaned in the preview rendering.

## Changes
- `RebaseIntentBuilder.ts`: Filter out remote branches when building `branchHeadIndex`
- `UiStateBuilder.ts`: Find oldest owned commit and move the entire chain together in preview
- Added documentation comment about consistency requirement between the two files

## Test plan
- [x] Added tests for remote branch handling (positive + negative cases)
- [x] Added test for branchless ancestors projection
- [x] Added test for single-commit branch edge case
- [x] All 53 related tests pass
- [x] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)