### PR TITLE
fix: show all owned commits in rebase preview

### DIFF
--- a/src/node/__tests__/domain/UiStateBuilder.intent-alt.test.ts
+++ b/src/node/__tests__/domain/UiStateBuilder.intent-alt.test.ts
@@ -348,12 +348,14 @@ function createStackNodeState(
   headSha: string,
   baseSha: string,
   branch: string,
-  children: StackNodeState[]
+  children: StackNodeState[],
+  ownedShas?: string[]
 ): StackNodeState {
   return {
     branch,
     headSha,
     baseSha,
+    ownedShas: ownedShas ?? [headSha],
     children
   }
 }

--- a/src/node/__tests__/domain/UiStateBuilder.intent.test.ts
+++ b/src/node/__tests__/domain/UiStateBuilder.intent.test.ts
@@ -415,7 +415,7 @@ describe('buildUiState (branchless ancestors projection)', () => {
       createdAtMs: Date.now(),
       targets: [
         {
-          node: createStackNodeState('C', 'trunk-sha', 'feature', []),
+          node: createStackNodeState('C', 'trunk-sha', 'feature', [], ['C', 'B', 'A']),
           targetBaseSha: 'target-sha'
         }
       ]
@@ -442,6 +442,11 @@ describe('buildUiState (branchless ancestors projection)', () => {
     expect(commitA).toBeDefined()
     expect(commitB).toBeDefined()
     expect(commitC).toBeDefined()
+
+    // Verify all owned commits have rebaseStatus: 'prompting' (not just head)
+    expect(commitA!.rebaseStatus).toBe('prompting')
+    expect(commitB!.rebaseStatus).toBe('prompting')
+    expect(commitC!.rebaseStatus).toBe('prompting')
 
     // The chain should be intact: A -> B -> C
     // And A should now be based on target-sha
@@ -515,12 +520,14 @@ function createStackNodeState(
   headSha: string,
   baseSha: string,
   branch: string,
-  children: StackNodeState[]
+  children: StackNodeState[],
+  ownedShas?: string[]
 ): StackNodeState {
   return {
     branch,
     headSha,
     baseSha,
+    ownedShas: ownedShas ?? [headSha],
     children
   }
 }

--- a/src/node/domain/RebaseIntentBuilder.ts
+++ b/src/node/domain/RebaseIntentBuilder.ts
@@ -124,14 +124,14 @@ export class RebaseIntentBuilder {
 
     visited.add(visitedKey)
 
-    // Find the base SHA by walking backwards through commits
-    const baseSha = RebaseIntentBuilder.calculateBranchBase(
+    // Calculate ownership - this gives us both baseSha and all owned commit SHAs
+    const { baseSha, ownedShas } = calculateCommitOwnership({
       headSha,
-      branchName,
+      branchRef: branchName,
       commitMap,
       branchHeadIndex,
       trunkShas
-    )
+    })
 
     // Find child branches - branches that depend on this branch's lineage
     const childBranches = RebaseIntentBuilder.findChildBranchesWithForkPoint(
@@ -165,6 +165,7 @@ export class RebaseIntentBuilder {
       branch: branchName,
       headSha,
       baseSha,
+      ownedShas,
       children
     }
   }

--- a/src/node/domain/UiStateBuilder.ts
+++ b/src/node/domain/UiStateBuilder.ts
@@ -839,7 +839,7 @@ export class UiStateBuilder {
     const idleShas = new Set<string>()
 
     for (const target of intent.targets) {
-      promptingShas.add(target.node.headSha)
+      target.node.ownedShas.forEach((sha) => promptingShas.add(sha))
       UiStateBuilder.collectChildShas(target.node.children, idleShas)
     }
 
@@ -848,7 +848,7 @@ export class UiStateBuilder {
 
   private static collectChildShas(children: StackNodeState[], result: Set<string>): void {
     for (const child of children) {
-      result.add(child.headSha)
+      child.ownedShas.forEach((sha) => result.add(sha))
       UiStateBuilder.collectChildShas(child.children, result)
     }
   }

--- a/src/node/domain/__tests__/StackAnalyzer.test.ts
+++ b/src/node/domain/__tests__/StackAnalyzer.test.ts
@@ -374,10 +374,12 @@ describe('StackAnalyzer', () => {
 // ============================================================================
 
 function createStackNode(branch: string, children: StackNodeState[]): StackNodeState {
+  const headSha = `sha-${branch}`
   return {
     branch,
-    headSha: `sha-${branch}`,
+    headSha,
     baseSha: `base-${branch}`,
+    ownedShas: [headSha],
     children
   }
 }

--- a/src/shared/types/rebase.ts
+++ b/src/shared/types/rebase.ts
@@ -92,6 +92,8 @@ export type StackNodeState = {
   branch: string
   headSha: string
   baseSha: string
+  /** All commit SHAs owned by this branch (head first, oldest last). */
+  ownedShas: string[]
   children: StackNodeState[]
 }
 


### PR DESCRIPTION
## Summary

- Fixed bug where clicking Rebase on a multi-commit branch only showed the branch head in the preview
- Added `ownedShas` field to `StackNodeState` to track all commits owned by a branch
- Updated `RebaseIntentBuilder` to capture `ownedShas` (reusing existing `calculateCommitOwnership` logic)
- Updated `applyRebaseStatusToStack` to mark all owned commits with the correct status

## Root Cause

The `ownedShas` was already being computed by `calculateCommitOwnership` but was being discarded - only `baseSha` was returned. This meant the rebase preview couldn't access the full list of owned commits, unlike drag-and-drop which had `branch.ownedCommitShas` pre-computed.

## Test plan

- [x] Click Rebase on a branch with multiple commits - all commits should appear in the preview
- [x] Verify drag-and-drop still works correctly
- [x] Run `pnpm test` - all rebase-related tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)