### PR TITLE
Fix drag position misalignment during scroll and add auto-scroll

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -12,6 +12,7 @@ import { Topbar } from './components/Topbar'
 import { ScrollArea, ScrollBar } from './components/ui/scroll-area'
 import { useForgeStateContext } from './contexts/ForgeStateContext'
 import { useLocalStateContext } from './contexts/LocalStateContext'
+import { useScrollViewport } from './contexts/ScrollViewportContext'
 import { useUiStateContext } from './contexts/UiStateContext'
 import { useUpdateNotifications } from './hooks/use-update-notifications'
 import { enrichStackWithForge } from './utils/enrich-stack-with-forge'
@@ -20,6 +21,7 @@ function App(): React.JSX.Element {
   const { uiState, repoError, isRebasingWithConflicts, queuedBranches } = useUiStateContext()
   const { forgeState } = useForgeStateContext()
   const { selectedRepo, addRepo } = useLocalStateContext()
+  const { setViewportRef } = useScrollViewport()
   useUpdateNotifications()
 
   // Merge forge state (PR data) into the UI stack at render time
@@ -41,7 +43,7 @@ function App(): React.JSX.Element {
     <TooltipProvider>
       <div className="flex h-screen flex-col">
         <TitleBar />
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1" viewportRef={setViewportRef}>
           <div className="px-6 pt-2 pb-32">
             <Topbar />
 

--- a/src/web/components/ui/scroll-area.tsx
+++ b/src/web/components/ui/scroll-area.tsx
@@ -5,16 +5,20 @@ import * as React from 'react'
 
 import { cn } from '../../utils/cn'
 
+interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
+  viewportRef?: (element: HTMLDivElement | null) => void
+}
+
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  ScrollAreaProps
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport ref={viewportRef} className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/web/contexts/ScrollViewportContext.tsx
+++ b/src/web/contexts/ScrollViewportContext.tsx
@@ -1,0 +1,44 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type RefObject
+} from 'react'
+
+interface ScrollViewportContextValue {
+  viewportRef: RefObject<HTMLElement | null>
+  setViewportRef: (element: HTMLElement | null) => void
+}
+
+const ScrollViewportContext = createContext<ScrollViewportContextValue | undefined>(undefined)
+
+export function ScrollViewportProvider({ children }: { children: ReactNode }): React.JSX.Element {
+  const viewportRef = useRef<HTMLElement | null>(null)
+
+  const setViewportRef = useCallback((element: HTMLElement | null): void => {
+    viewportRef.current = element
+  }, [])
+
+  const value = useMemo(
+    () => ({ viewportRef, setViewportRef }),
+    [setViewportRef]
+  )
+
+  return (
+    <ScrollViewportContext.Provider value={value}>
+      {children}
+    </ScrollViewportContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useScrollViewport(): ScrollViewportContextValue {
+  const context = useContext(ScrollViewportContext)
+  if (context === undefined) {
+    throw new Error('useScrollViewport must be used within a ScrollViewportProvider')
+  }
+  return context
+}

--- a/src/web/main.tsx
+++ b/src/web/main.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { DragProvider } from './contexts/DragContext'
 import { ForgeStateProvider } from './contexts/ForgeStateContext'
 import { LocalStateProvider, useLocalStateContext } from './contexts/LocalStateContext'
+import { ScrollViewportProvider } from './contexts/ScrollViewportContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { UiStateProvider } from './contexts/UiStateContext'
 import { UtilityModalsProvider } from './contexts/UtilityModalsContext'
@@ -21,12 +22,14 @@ function AppWithProviders(): React.JSX.Element {
     <ForgeStateProvider repoPath={repoPath}>
       <UiStateProvider selectedRepoPath={repoPath}>
         <UtilityModalsProvider>
-          <DragProvider>
-            <ErrorBoundary>
-              <App />
-            </ErrorBoundary>
-            <DragCursor />
-          </DragProvider>
+          <ScrollViewportProvider>
+            <DragProvider>
+              <ErrorBoundary>
+                <App />
+              </ErrorBoundary>
+              <DragCursor />
+            </DragProvider>
+          </ScrollViewportProvider>
         </UtilityModalsProvider>
       </UiStateProvider>
     </ForgeStateProvider>

--- a/src/web/utils/__tests__/dragging.test.ts
+++ b/src/web/utils/__tests__/dragging.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { findClosestCommitBelowMouse, type CommitBoundingBox } from '../dragging'
+
+describe('findClosestCommitBelowMouse', () => {
+  const createBoxes = (...centerYs: number[]): CommitBoundingBox[] =>
+    centerYs.map((centerY, i) => ({ sha: `sha${i}`, centerY }))
+
+  describe('without scroll compensation', () => {
+    it('returns null when no commits are below mouse', () => {
+      const boxes = createBoxes(100, 200, 300)
+      const result = findClosestCommitBelowMouse(400, boxes, 0, 0)
+      expect(result).toBeNull()
+    })
+
+    it('returns closest commit below mouse', () => {
+      const boxes = createBoxes(100, 200, 300, 400)
+      const result = findClosestCommitBelowMouse(150, boxes, 0, 0)
+      expect(result).toBe('sha1') // centerY 200 is closest below 150
+    })
+
+    it('returns null for empty boxes', () => {
+      const result = findClosestCommitBelowMouse(100, [], 0, 0)
+      expect(result).toBeNull()
+    })
+
+    it('ignores commits above or at mouse position', () => {
+      const boxes = createBoxes(100, 150, 200)
+      const result = findClosestCommitBelowMouse(150, boxes, 0, 0)
+      expect(result).toBe('sha2') // Only 200 is strictly below 150
+    })
+  })
+
+  describe('with scroll compensation', () => {
+    it('adjusts for scroll down (positive delta)', () => {
+      // User started drag at scrollTop=0, now scrolled to scrollTop=100
+      // Commit was at viewport Y=300 when captured
+      // After scrolling down 100px, commit visually moved to Y=200
+      // Mouse at Y=250 should find the commit (adjusted: 250+100=350, 300 < 350 so not below)
+      const boxes = createBoxes(300, 400)
+
+      // Mouse at 250, scroll delta +100 -> adjusted mouse at 350
+      // 300 is NOT > 350, 400 IS > 350
+      const result = findClosestCommitBelowMouse(250, boxes, 0, 100)
+      expect(result).toBe('sha1') // centerY 400, adjusted distance = 50
+    })
+
+    it('adjusts for scroll up (negative delta)', () => {
+      // User started drag at scrollTop=100, now scrolled to scrollTop=0
+      // Commit was at viewport Y=200 when captured
+      // After scrolling up 100px, commit visually moved to Y=300
+      const boxes = createBoxes(200, 300)
+
+      // Mouse at 250, scroll delta -100 -> adjusted mouse at 150
+      // 200 IS > 150 (distance 50), 300 IS > 150 (distance 150)
+      const result = findClosestCommitBelowMouse(250, boxes, 100, 0)
+      expect(result).toBe('sha0') // centerY 200, closest below adjusted mouse 150
+    })
+
+    it('handles no scroll change', () => {
+      const boxes = createBoxes(100, 200, 300)
+      const result = findClosestCommitBelowMouse(150, boxes, 50, 50)
+      expect(result).toBe('sha1') // Same as no scroll
+    })
+
+    it('correctly identifies target after large scroll', () => {
+      // Simulate scrolling down 500px
+      const boxes = createBoxes(100, 200, 300, 400, 500, 600)
+
+      // Mouse at Y=100, scroll delta +500 -> adjusted mouse at 600
+      // Only 600 could be below, but 600 is NOT > 600
+      const result = findClosestCommitBelowMouse(100, boxes, 0, 500)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles mouse exactly at commit position', () => {
+      const boxes = createBoxes(100, 200, 300)
+      // Mouse at exactly 200 - commit at 200 is NOT below (not strictly greater)
+      const result = findClosestCommitBelowMouse(200, boxes, 0, 0)
+      expect(result).toBe('sha2') // 300 is the only one strictly below
+    })
+
+    it('handles single commit', () => {
+      const boxes = createBoxes(200)
+      expect(findClosestCommitBelowMouse(100, boxes, 0, 0)).toBe('sha0')
+      expect(findClosestCommitBelowMouse(200, boxes, 0, 0)).toBeNull()
+      expect(findClosestCommitBelowMouse(300, boxes, 0, 0)).toBeNull()
+    })
+  })
+})

--- a/src/web/utils/dragging.ts
+++ b/src/web/utils/dragging.ts
@@ -7,16 +7,23 @@ export interface CommitBoundingBox {
   centerY: number
 }
 
+export interface CapturedDragState {
+  boundingBoxes: CommitBoundingBox[]
+  initialScrollTop: number
+}
+
 /**
- * Captures the initial bounding boxes of all commits at drag start.
+ * Captures the initial bounding boxes of all commits and scroll position at drag start.
  * These positions are frozen and used throughout the drag operation to prevent
  * flickering when the optimistic UI updates.
  */
 export function captureCommitBoundingBoxes(
   commitRefsMap: Map<string, RefObject<HTMLDivElement>>,
-  stacks: UiStack
-): CommitBoundingBox[] {
+  stacks: UiStack,
+  scrollViewport: HTMLElement | null
+): CapturedDragState {
   const boundingBoxes: CommitBoundingBox[] = []
+  const initialScrollTop = scrollViewport?.scrollTop ?? 0
 
   for (const [sha, ref] of commitRefsMap.entries()) {
     const commit = getUiCommitBySha(stacks, sha)
@@ -32,24 +39,34 @@ export function captureCommitBoundingBoxes(
     boundingBoxes.push({ sha, centerY: commitCenterY })
   }
 
-  return boundingBoxes
+  return { boundingBoxes, initialScrollTop }
 }
 
 /**
  * Finds the closest commit below the mouse cursor using pre-captured bounding boxes.
+ * Compensates for scroll changes since drag start.
  * This prevents flickering by using stable positions throughout the drag operation.
  */
 export function findClosestCommitBelowMouse(
   mouseY: number,
-  boundingBoxes: CommitBoundingBox[]
+  boundingBoxes: CommitBoundingBox[],
+  initialScrollTop: number,
+  currentScrollTop: number
 ): string | null {
+  // Calculate scroll delta: how much has been scrolled since drag start
+  const scrollDelta = currentScrollTop - initialScrollTop
+
+  // Adjust mouseY to account for scroll change
+  // When user scrolls down, elements move up in viewport, so we add scrollDelta
+  const adjustedMouseY = mouseY + scrollDelta
+
   let closestSha: string | null = null
   let closestDistance = Infinity
 
   for (const box of boundingBoxes) {
     // Only consider commits that are below the mouse
-    if (box.centerY > mouseY) {
-      const distance = box.centerY - mouseY
+    if (box.centerY > adjustedMouseY) {
+      const distance = box.centerY - adjustedMouseY
       if (distance < closestDistance) {
         closestDistance = distance
         closestSha = box.sha


### PR DESCRIPTION
## Summary

- **Fixes scroll wheel bug**: When dragging a branch and scrolling with mouse wheel, the drop target calculation became misaligned. The frozen bounding boxes used viewport-relative coordinates without accounting for scroll position changes.
- **Adds auto-scroll**: When dragging a branch to the top or bottom edge of the viewport, the view now automatically scrolls to reveal more content.

## Implementation

1. **Scroll compensation**: Track `initialScrollTop` at drag start, compute `scrollDelta` during drag, and adjust mouse Y position before comparing against frozen bounding boxes.

2. **Auto-scroll**: RAF loop detects cursor within 60px of viewport edges and scrolls proportionally (faster near edge, max 15px/frame). Continues scrolling even when cursor moves past the viewport boundary.

3. **New `ScrollViewportContext`**: Shares the scroll viewport ref between `App.tsx` and `DragContext.tsx` to enable both features.

## Test plan

- [x] Start dragging a branch, scroll with mouse wheel, verify drop indicator stays on correct visual target
- [x] Release on a target after scrolling, verify rebase applies to correct commit
- [x] Drag branch to bottom edge, verify auto-scroll begins
- [x] Drag branch to top edge, verify auto-scroll begins
- [x] Move cursor away from edge while dragging, verify scroll stops
- [x] Run `npm test` - new unit tests for scroll compensation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)