### PR TITLE
fix: show open PR instead of closed when multiple PRs exist

### DIFF
--- a/src/node/domain/PrTargetResolver.ts
+++ b/src/node/domain/PrTargetResolver.ts
@@ -8,6 +8,7 @@
 
 import type { Commit, Repo } from '@shared/types'
 import type { ForgePullRequest } from '@shared/types/git-forge'
+import { findBestPr } from '@shared/types/git-forge'
 import { extractLocalBranchName, isTrunk } from '@shared/types/repo'
 import { buildTrunkShaSet } from './CommitOwnership'
 import { TrunkResolver } from './TrunkResolver'
@@ -207,7 +208,7 @@ export class PrTargetResolver {
       visited.add(current)
 
       // Find the PR for this branch to get its target
-      const pr = pullRequests.find((p) => p.headRefName === current)
+      const pr = findBestPr(current, pullRequests)
 
       if (!pr) {
         // Can't trace further - fall back to trunk if provided, otherwise error

--- a/src/node/operations/PullRequestOperation.ts
+++ b/src/node/operations/PullRequestOperation.ts
@@ -10,7 +10,7 @@
 import { log } from '@shared/logger'
 import type { Branch, Repo } from '@shared/types'
 import { extractLocalBranchName } from '@shared/types'
-import { findOpenPr, type MergeStrategy } from '@shared/types/git-forge'
+import { findBestPr, findOpenPr, type MergeStrategy } from '@shared/types/git-forge'
 import { isTrunk } from '@shared/types/repo'
 import { getGitAdapter, supportsMerge, type GitAdapter } from '../adapters/git'
 import { PrTargetResolver, ShipItNavigator } from '../domain'
@@ -230,7 +230,7 @@ export class PullRequestOperation {
   ): Promise<void> {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const { state } = await gitForgeService.refreshWithStatus(repoPath)
-      const pr = state.pullRequests.find((p) => p.headRefName === branchName)
+      const pr = findBestPr(branchName, state.pullRequests)
 
       if (pr?.headSha === expectedSha) {
         log.debug(`[PullRequestOperation] PR synced after ${attempt} attempt(s)`)

--- a/src/node/operations/__tests__/ParallelRebase.test.ts
+++ b/src/node/operations/__tests__/ParallelRebase.test.ts
@@ -359,7 +359,8 @@ describe('Parallel Rebase Workflow', () => {
   })
 
   describe('Concurrent operations', () => {
-    it('prevents concurrent rebase sessions on same repo', async () => {
+    // This test can be flaky under heavy system load due to git operations and file I/O
+    it('prevents concurrent rebase sessions on same repo', { timeout: 10000 }, async () => {
       // Arrange: Add a commit to main so rebase is needed
       execSync('git checkout main', { cwd: repoPath })
       await fs.promises.writeFile(path.join(repoPath, 'main-update.txt'), 'main update')

--- a/src/shared/types/__tests__/git-forge.test.ts
+++ b/src/shared/types/__tests__/git-forge.test.ts
@@ -5,7 +5,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   ACTIVE_PR_STATES,
+  canRecreatePr,
+  countOpenPrs,
   findActivePr,
+  findBestPr,
   findOpenPr,
   hasChildPrs,
   hasMergedPr,
@@ -237,5 +240,239 @@ describe('hasMergedPr', () => {
       makePr('feature-1', 'merged') // has a merged PR too
     ]
     expect(hasMergedPr('feature-1', prs)).toBe(true)
+  })
+})
+
+describe('findBestPr', () => {
+  const makePr = (head: string, state: string, createdAt?: string) => ({
+    headRefName: head,
+    state,
+    createdAt
+  })
+
+  it('returns undefined when no PR exists for branch', () => {
+    expect(findBestPr('feature-1', [])).toBeUndefined()
+    expect(findBestPr('feature-1', [makePr('feature-2', 'open')])).toBeUndefined()
+  })
+
+  it('returns single matching PR', () => {
+    const prs = [makePr('feature-1', 'open')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('prefers open over draft', () => {
+    const prs = [makePr('feature-1', 'draft', '2024-01-01'), makePr('feature-1', 'open', '2024-01-01')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('prefers open over closed', () => {
+    const prs = [makePr('feature-1', 'closed', '2024-01-15'), makePr('feature-1', 'open', '2024-01-01')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('prefers open over closed regardless of creation order', () => {
+    // Closed PR created more recently should still be lower priority than open PR
+    const prs = [
+      makePr('feature-1', 'open', '2024-01-01'),
+      makePr('feature-1', 'closed', '2024-01-20')
+    ]
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('prefers draft over merged', () => {
+    const prs = [makePr('feature-1', 'merged', '2024-01-02'), makePr('feature-1', 'draft', '2024-01-01')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('draft')
+  })
+
+  it('prefers merged over closed', () => {
+    const prs = [makePr('feature-1', 'closed', '2024-01-02'), makePr('feature-1', 'merged', '2024-01-01')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('merged')
+  })
+
+  it('prefers most recently created within same state', () => {
+    const prs = [
+      makePr('feature-1', 'closed', '2024-01-01'),
+      makePr('feature-1', 'closed', '2024-01-15') // More recent
+    ]
+    expect(findBestPr('feature-1', prs)?.createdAt).toBe('2024-01-15')
+  })
+
+  it('handles missing createdAt gracefully', () => {
+    const prs = [makePr('feature-1', 'open'), makePr('feature-1', 'closed', '2024-01-01')]
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('preserves additional properties on returned PR', () => {
+    const prs = [{ headRefName: 'feature-1', state: 'open', createdAt: '2024-01-01', number: 123 }]
+    const result = findBestPr('feature-1', prs)
+    expect(result).toEqual({ headRefName: 'feature-1', state: 'open', createdAt: '2024-01-01', number: 123 })
+  })
+
+  it('does not mutate input array', () => {
+    const prs = [makePr('feature-1', 'closed', '2024-01-15'), makePr('feature-1', 'open', '2024-01-01')]
+    const originalOrder = [...prs]
+    findBestPr('feature-1', prs)
+    expect(prs).toEqual(originalOrder)
+  })
+
+  // Edge cases for date parsing
+  it('handles invalid createdAt dates gracefully - does not throw', () => {
+    const prs = [
+      makePr('feature-1', 'open', 'invalid-date'),
+      makePr('feature-1', 'open', '2024-01-01')
+    ]
+    // Should not throw - invalid dates result in NaN comparison, order may vary
+    // The key guarantee is no exception
+    const result = findBestPr('feature-1', prs)
+    expect(result).toBeDefined()
+    expect(result?.state).toBe('open')
+  })
+
+  it('handles empty string createdAt gracefully', () => {
+    const prs = [
+      makePr('feature-1', 'closed', ''),
+      makePr('feature-1', 'closed', '2024-01-15')
+    ]
+    expect(findBestPr('feature-1', prs)?.createdAt).toBe('2024-01-15')
+  })
+
+  it('handles both PRs having invalid dates', () => {
+    const prs = [
+      makePr('feature-1', 'open', 'bad'),
+      makePr('feature-1', 'open', 'also-bad')
+    ]
+    // Should not throw, returns one of them (both have equal priority)
+    const result = findBestPr('feature-1', prs)
+    expect(result).toBeDefined()
+    expect(result?.state).toBe('open')
+  })
+
+  // Complex multi-PR scenarios (3+ PRs)
+  it('handles 3+ PRs with mixed states correctly', () => {
+    const prs = [
+      makePr('feature-1', 'closed', '2024-01-03'),
+      makePr('feature-1', 'draft', '2024-01-02'),
+      makePr('feature-1', 'open', '2024-01-01'),
+      makePr('feature-1', 'merged', '2024-01-04')
+    ]
+    // Should select open (highest priority) regardless of array order
+    expect(findBestPr('feature-1', prs)?.state).toBe('open')
+  })
+
+  it('handles 3+ PRs all with same state - selects newest', () => {
+    const prs = [
+      makePr('feature-1', 'closed', '2024-01-01'),
+      makePr('feature-1', 'closed', '2024-01-15'),
+      makePr('feature-1', 'closed', '2024-01-10')
+    ]
+    expect(findBestPr('feature-1', prs)?.createdAt).toBe('2024-01-15')
+  })
+
+  it('handles multiple open PRs - selects newest open', () => {
+    const prs = [
+      makePr('feature-1', 'open', '2024-01-01'),
+      makePr('feature-1', 'open', '2024-01-20'),
+      makePr('feature-1', 'open', '2024-01-10'),
+      makePr('feature-1', 'closed', '2024-01-25') // Newer but lower priority
+    ]
+    const result = findBestPr('feature-1', prs)
+    expect(result?.state).toBe('open')
+    expect(result?.createdAt).toBe('2024-01-20')
+  })
+
+  it('handles 5+ PRs with complex state and date combinations', () => {
+    const prs = [
+      makePr('feature-1', 'merged', '2024-01-25'),
+      makePr('feature-1', 'closed', '2024-01-30'),
+      makePr('feature-1', 'draft', '2024-01-05'),
+      makePr('feature-1', 'draft', '2024-01-15'),
+      makePr('feature-1', 'closed', '2024-01-01')
+    ]
+    // No open PR, so draft with newest date should be selected
+    const result = findBestPr('feature-1', prs)
+    expect(result?.state).toBe('draft')
+    expect(result?.createdAt).toBe('2024-01-15')
+  })
+})
+
+describe('countOpenPrs', () => {
+  const makePr = (head: string, state: string) => ({
+    headRefName: head,
+    state
+  })
+
+  it('returns 0 for no matching PRs', () => {
+    expect(countOpenPrs('feature-1', [])).toBe(0)
+    expect(countOpenPrs('feature-1', [makePr('feature-2', 'open')])).toBe(0)
+  })
+
+  it('counts only open PRs', () => {
+    const prs = [
+      makePr('feature-1', 'open'),
+      makePr('feature-1', 'draft'),
+      makePr('feature-1', 'open'),
+      makePr('feature-1', 'closed')
+    ]
+    expect(countOpenPrs('feature-1', prs)).toBe(2)
+  })
+
+  it('returns 1 for single open PR', () => {
+    const prs = [makePr('feature-1', 'open')]
+    expect(countOpenPrs('feature-1', prs)).toBe(1)
+  })
+
+  it('returns 0 when only draft/closed/merged PRs exist', () => {
+    const prs = [
+      makePr('feature-1', 'draft'),
+      makePr('feature-1', 'closed'),
+      makePr('feature-1', 'merged')
+    ]
+    expect(countOpenPrs('feature-1', prs)).toBe(0)
+  })
+})
+
+describe('canRecreatePr', () => {
+  const makePr = (head: string, state: string) => ({
+    headRefName: head,
+    state
+  })
+
+  it('returns false when no PRs exist', () => {
+    expect(canRecreatePr('feature-1', [])).toBe(false)
+  })
+
+  it('returns false when open PR exists', () => {
+    const prs = [makePr('feature-1', 'open')]
+    expect(canRecreatePr('feature-1', prs)).toBe(false)
+  })
+
+  it('returns false when draft PR exists', () => {
+    const prs = [makePr('feature-1', 'draft')]
+    expect(canRecreatePr('feature-1', prs)).toBe(false)
+  })
+
+  it('returns true when only closed PRs exist', () => {
+    const prs = [makePr('feature-1', 'closed')]
+    expect(canRecreatePr('feature-1', prs)).toBe(true)
+  })
+
+  it('returns true when only merged PRs exist', () => {
+    const prs = [makePr('feature-1', 'merged')]
+    expect(canRecreatePr('feature-1', prs)).toBe(true)
+  })
+
+  it('returns true when only closed and merged PRs exist', () => {
+    const prs = [makePr('feature-1', 'closed'), makePr('feature-1', 'merged')]
+    expect(canRecreatePr('feature-1', prs)).toBe(true)
+  })
+
+  it('returns false when at least one active PR exists among inactive ones', () => {
+    const prs = [makePr('feature-1', 'closed'), makePr('feature-1', 'open')]
+    expect(canRecreatePr('feature-1', prs)).toBe(false)
+  })
+
+  it('returns false for different branch', () => {
+    const prs = [makePr('feature-2', 'closed')]
+    expect(canRecreatePr('feature-1', prs)).toBe(false)
   })
 })

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -100,6 +100,8 @@ export type UiBranch = {
   squashDisabledReason?: string
   /** True if a new worktree can be created for this branch. False for remote and trunk branches. */
   canCreateWorktree: boolean
+  /** True if this branch can recreate a PR (has only closed/merged PRs, no active ones). */
+  canRecreatePr?: boolean
 }
 
 /**
@@ -140,6 +142,11 @@ export type UiPullRequest = {
    * Only populated for open PRs.
    */
   mergeReadiness?: MergeReadiness
+  /**
+   * True if multiple open PRs exist for this branch.
+   * This is a warning condition - normally a branch should have at most one open PR.
+   */
+  hasMultipleOpenPrs?: boolean
 }
 
 export type UiWorkingTreeFile = {

--- a/src/web/utils/__tests__/pr-state-styles.test.ts
+++ b/src/web/utils/__tests__/pr-state-styles.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { getPrStateStyles } from '../pr-state-styles'
+
+describe('getPrStateStyles', () => {
+  it('returns green styling for open PRs', () => {
+    const result = getPrStateStyles('open')
+    expect(result.textClass).toBe('text-green-500')
+    expect(result.label).toBe('')
+  })
+
+  it('returns muted styling with draft label for draft PRs', () => {
+    const result = getPrStateStyles('draft')
+    expect(result.textClass).toBe('text-muted-foreground')
+    expect(result.label).toBe(' (Draft)')
+  })
+
+  it('returns red styling with closed label for closed PRs', () => {
+    const result = getPrStateStyles('closed')
+    expect(result.textClass).toBe('text-red-500')
+    expect(result.label).toBe(' (Closed)')
+  })
+
+  it('returns purple styling with merged label for merged PRs', () => {
+    const result = getPrStateStyles('merged')
+    expect(result.textClass).toBe('text-purple-500')
+    expect(result.label).toBe(' (Merged)')
+  })
+
+  it('returns muted styling with no label for unknown states', () => {
+    const result = getPrStateStyles('unknown')
+    expect(result.textClass).toBe('text-muted-foreground')
+    expect(result.label).toBe('')
+  })
+
+  it('handles empty string state', () => {
+    const result = getPrStateStyles('')
+    expect(result.textClass).toBe('text-muted-foreground')
+    expect(result.label).toBe('')
+  })
+
+  it('is case-sensitive (uppercase states fall through to default)', () => {
+    const result = getPrStateStyles('OPEN')
+    expect(result.textClass).toBe('text-muted-foreground')
+    expect(result.label).toBe('')
+  })
+})

--- a/src/web/utils/pr-state-styles.ts
+++ b/src/web/utils/pr-state-styles.ts
@@ -1,0 +1,32 @@
+/**
+ * PR state-based styling utilities.
+ * Provides consistent visual styling for PR state across the UI.
+ */
+
+export interface PrStateStyles {
+  /** Tailwind CSS class for text color */
+  textClass: string
+  /** Label suffix to append to PR number (e.g., ' (Closed)') */
+  label: string
+}
+
+/**
+ * Returns styling information for a PR based on its state.
+ *
+ * @param state - The PR state ('open', 'draft', 'closed', 'merged')
+ * @returns Styling information including text class and label suffix
+ */
+export function getPrStateStyles(state: string): PrStateStyles {
+  switch (state) {
+    case 'open':
+      return { textClass: 'text-green-500', label: '' }
+    case 'draft':
+      return { textClass: 'text-muted-foreground', label: ' (Draft)' }
+    case 'closed':
+      return { textClass: 'text-red-500', label: ' (Closed)' }
+    case 'merged':
+      return { textClass: 'text-purple-500', label: ' (Merged)' }
+    default:
+      return { textClass: 'text-muted-foreground', label: '' }
+  }
+}


### PR DESCRIPTION
## Summary

- **Bug fix**: When a branch has multiple PRs (e.g., after closing and recreating), Teapot now correctly shows the open PR instead of the closed one using priority-based selection (open > draft > merged > closed)
- **UX improvement**: Added visible "Create PR" button next to closed PRs for better discoverability
- **UX improvement**: Hide CI checks icon when PR has merge conflicts (reduces visual noise)
- **UX improvement**: Added "Multiple PRs" warning badge when multiple open PRs exist for same branch
- **UX improvement**: Added tooltips for "Has conflicts" and "Multiple PRs" states

## Technical changes

- New `findBestPr()` function for priority-based PR selection (shared between frontend and backend)
- Optimistic PR state updates after creation to handle GitHub's eventual consistency
- Debug logging when non-open PR is selected (helps diagnose issues)
- Extracted `getPrStateStyles()` to testable utility

## Test plan

- [x] 754 tests pass (including new tests for multi-PR scenarios)
- [x] Build passes with no type errors
- [ ] Manual test: Close a PR, create a new one for the same branch, verify new PR shows in green
- [ ] Manual test: Verify "Create PR" button appears next to closed PRs
- [ ] Manual test: Verify "Has conflicts" tooltip appears on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)