### PR TITLE
fix: restore drag initiation from entire commit row

### DIFF
--- a/src/web/components/MultiBranchBadge.tsx
+++ b/src/web/components/MultiBranchBadge.tsx
@@ -80,10 +80,6 @@ export const MultiBranchBadge = memo(function MultiBranchBadge({
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <button
-              onClick={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-              }}
               onMouseDown={(e) => e.stopPropagation()}
               className={cn(
                 'inline-flex w-[1.625rem] items-center justify-center rounded-lg py-1 text-xs font-medium transition-colors',

--- a/src/web/components/StackView.tsx
+++ b/src/web/components/StackView.tsx
@@ -370,10 +370,11 @@ export const CommitView = memo(function CommitView({
           isPartOfRebasePlan && 'bg-accent/30',
           isBeingDragged && 'bg-accent/10'
         )}
+        onMouseDown={onCommitDotMouseDown}
       >
         {/* Drop indicator - shown/hidden via direct DOM manipulation in DragContext */}
         <div className="drop-indicator bg-accent absolute -top-px left-0 hidden h-[3px] w-full" />
-        <div onMouseDown={onCommitDotMouseDown}>
+        <div>
           <CommitDot
             top={!isOwned && showTopLine}
             bottom={!isOwned && showBottomLine}


### PR DESCRIPTION
## Summary
- Fix regression where dragging could only be initiated by clicking the commit dot
- Move `onMouseDown` handler back to the parent commit row div so clicking anywhere on the row (commit dot, branch badge, or message) initiates dragging
- Fix "+N" popover button not opening - removed `onClick` with `preventDefault()` that was blocking Radix's PopoverTrigger
- Root cause: UI refactor in 7bd498d accidentally moved the handler to only wrap CommitDot

## Test plan
- [x] Click and drag from a branch badge to reorder
- [x] Click and drag from the commit message to reorder
- [x] Click and drag from the commit dot to reorder
- [x] Verify the "+N" button on MultiBranchBadge opens the popover
- [x] Verify clicking inside the popover doesn't initiate drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)