### PR TITLE
docs: add feature specs folder for implemented features

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Each branch has one focused change. Reviewers see small diffs. Reviews go faster
 
 Small PRs get reviewed quickly. You ship code while the next piece is still in review. Your git history stays clean.
 
+## Documentation
+
+- **[Feature Specifications](./docs/feature-specs/README.md)**: Detailed specs for implemented features, enabling reimplementation by any engineer
+- **[Ideas](./docs/ideas/README.md)**: Proposed improvements and future features
+
 ## Contributing
 
 Found a bug or have an idea? [Open an issue](https://github.com/jhleao/teapot/issues).

--- a/docs/feature-specs/01-sticky-repository-selector.md
+++ b/docs/feature-specs/01-sticky-repository-selector.md
@@ -1,0 +1,345 @@
+# Feature Specification: Sticky Repository Selector
+
+## Overview
+
+The Repository Selector is a persistent UI element that allows users to identify and switch between Git repositories. It remains fixed at the top of the viewport while scrolling through commit lists, ensuring users always have context of which repository they're viewing.
+
+---
+
+## Problem Statement
+
+### User Pain Points
+
+1. **Context Loss During Scrolling**: When viewing long commit histories, users scroll deep into the list and lose sight of which repository they're currently viewing. This causes confusion, especially when working with multiple similar repositories.
+
+2. **Right-Aligned Element Clipping**: The previous repository selector was positioned on the right side of the header. When commits have long messages, horizontal overflow causes the right-aligned selector to be pushed off-screen and become inaccessible.
+
+3. **Redundant UI Elements**: The previous design had two separate elements displaying repository information—a display-only metadata component and a separate dropdown selector—creating visual clutter and wasted space.
+
+---
+
+## Solution
+
+A unified, left-aligned, sticky repository selector that:
+- Stays visible at all times during scrolling
+- Combines display and selection functionality into a single compact element
+- Positions content on the left to avoid clipping issues
+
+---
+
+## Feature Requirements
+
+### FR-1: Sticky Positioning
+
+The repository selector header must remain fixed at the top of the viewport when the user scrolls through the commit list.
+
+**Acceptance Criteria:**
+- The header does not scroll with the content
+- The header remains visible regardless of scroll position
+- The header appears directly below the window title bar
+- A subtle bottom border visually separates the header from scrollable content
+
+### FR-2: Repository Display
+
+The selector displays the current repository name in a compact, single-line format.
+
+**Acceptance Criteria:**
+- Display only the folder name (final path segment), not the full path
+- Example: `/Users/dev/projects/my-app` displays as `my-app`
+- Text styling: medium weight, standard foreground color
+- Font size: small (consistent with other UI controls)
+
+### FR-3: Full Path Tooltip
+
+The complete repository path is accessible via tooltip for users who need the full context.
+
+**Acceptance Criteria:**
+- Tooltip appears on hover over the repository name
+- Tooltip displays the complete absolute path
+- Tooltip appears instantly (no delay)
+- Tooltip position: below the trigger element
+
+### FR-4: Dropdown Interaction
+
+Clicking the repository name opens a dropdown menu for repository selection.
+
+**Acceptance Criteria:**
+- Chevron icon indicates dropdown affordance
+- Chevron rotates 180° when dropdown is open
+- Click toggles dropdown open/closed
+- Clicking outside the dropdown closes it
+- Pressing Escape key closes the dropdown
+- Hover state: subtle background highlight on the clickable area
+
+### FR-5: Repository List
+
+The dropdown displays all registered repositories with selection state.
+
+**Acceptance Criteria:**
+- List shows all repositories in the user's workspace
+- Currently selected repository is visually highlighted
+- Selected repository shows a checkmark icon
+- Unselected repositories show a folder icon
+- Each item displays:
+  - Folder name (primary text, medium weight)
+  - Full path (secondary text, muted color, smaller size)
+- Maximum height with scroll for long lists (approximately 24rem)
+- Empty state message when no repositories are registered
+
+### FR-6: Repository Selection
+
+Users can switch repositories by selecting from the dropdown.
+
+**Acceptance Criteria:**
+- Clicking a repository item selects it
+- Dropdown closes after selection
+- Application state updates to reflect new repository
+- Selection is immediate (no confirmation required)
+
+### FR-7: Repository Management Actions
+
+The dropdown provides actions to add or remove repositories.
+
+**Add Repository:**
+- Button labeled "Add Repository" with plus icon
+- Opens system folder picker dialog
+- Selected folder is added to the repository list
+- Dropdown closes after action
+
+**Clone Repository:**
+- Button labeled "Clone Repository" with download icon
+- Opens clone dialog for entering repository URL
+- Successfully cloned repository is automatically selected
+- Dropdown closes after initiating action
+
+**Remove Repository:**
+- Each repository item has a remove button (X icon)
+- Remove button appears on the right side of each item
+- Clicking remove button removes repository from list
+- Remove action does not delete files, only removes from app
+- Remove button has destructive hover state (red tint)
+- Clicking remove does not trigger repository selection
+
+### FR-8: Worktree Badge
+
+When the user is working in a Git worktree (not the main repository), a badge indicates this state.
+
+**Acceptance Criteria:**
+- Badge appears next to the repository name
+- Badge indicates "worktree" or shows worktree path
+- Badge only appears when active worktree differs from main repository path
+- Compact variant styling (small, unobtrusive)
+
+### FR-9: Forge Status Indicator
+
+A status indicator showing the connection state to the Git forge (GitHub, GitLab, etc.) appears inline with the repository selector.
+
+**Acceptance Criteria:**
+- Indicator appears to the right of the repository name (and worktree badge if present)
+- Shows current forge connection status
+- Does not interfere with repository selection functionality
+
+---
+
+## Edge Cases
+
+### EC-1: No Repository Selected
+
+**Scenario:** Application launches with no repository selected or all repositories removed.
+
+**Behavior:**
+- Display placeholder text: "No repository selected"
+- Muted text styling
+- No dropdown functionality (nothing to show)
+- User must use empty state action or menu to add repository
+
+### EC-2: Very Long Repository Names
+
+**Scenario:** Repository folder name is unusually long (e.g., "my-extremely-long-project-name-with-many-words").
+
+**Behavior:**
+- Name displays without truncation in the header (header accommodates width)
+- Dropdown items truncate long names with ellipsis
+- Full path in dropdown provides complete context
+- Tooltip always shows complete path
+
+### EC-3: Very Long Repository Paths
+
+**Scenario:** Repository is deeply nested (e.g., "/Users/developer/work/client/project/submodule/component").
+
+**Behavior:**
+- Header shows only folder name (last segment)
+- Tooltip shows complete path
+- Dropdown items truncate paths with ellipsis
+- Paths truncate from the beginning to preserve the folder name
+
+### EC-4: Many Repositories
+
+**Scenario:** User has 20+ repositories registered.
+
+**Behavior:**
+- Dropdown becomes scrollable after reaching maximum height
+- Scroll container has maximum height of approximately 24rem (384px)
+- Scrollbar appears when content exceeds container
+- Current selection remains visible/scrolled into view when dropdown opens
+
+### EC-5: Single Repository
+
+**Scenario:** User has only one repository registered.
+
+**Behavior:**
+- Dropdown still functions normally
+- User can still access Add/Clone/Remove actions
+- No special handling required
+
+### EC-6: Rapid Repository Switching
+
+**Scenario:** User quickly switches between repositories multiple times.
+
+**Behavior:**
+- Each selection triggers immediate state update
+- No debouncing or throttling on selection
+- Previous async operations (if any) are superseded by new selection
+
+### EC-7: Repository Removal While Selected
+
+**Scenario:** User removes the currently selected repository.
+
+**Behavior:**
+- Repository is removed from list
+- Application handles the orphaned selection state
+- May fall back to no selection or first available repository (implementation dependent)
+
+### EC-8: Failed Repository Operations
+
+**Scenario:** Adding or cloning a repository fails (invalid path, network error, etc.).
+
+**Behavior:**
+- Error feedback provided via toast notification
+- Dropdown may remain open or close (implementation dependent)
+- Existing repository list unchanged
+- User can retry operation
+
+### EC-9: Dropdown Positioning Near Viewport Edges
+
+**Scenario:** Dropdown would extend beyond viewport boundaries.
+
+**Behavior:**
+- Dropdown repositions to stay within viewport
+- If no room below, dropdown may appear above trigger
+- If no room on right, dropdown shifts left
+- Minimum padding from viewport edges (8px)
+
+### EC-10: Keyboard Accessibility
+
+**Scenario:** User navigates via keyboard.
+
+**Behavior:**
+- Trigger button is focusable via Tab
+- Enter/Space opens dropdown
+- Escape closes dropdown
+- Focus management follows accessibility best practices
+
+### EC-11: Tooltip and Dropdown Conflict
+
+**Scenario:** User hovers to see tooltip then clicks to open dropdown.
+
+**Behavior:**
+- Tooltip hides when dropdown opens
+- Tooltip does not interfere with dropdown interaction
+- Only one overlay (tooltip or dropdown) visible at a time
+
+### EC-12: Window Resize
+
+**Scenario:** User resizes application window while dropdown is open.
+
+**Behavior:**
+- Dropdown repositions if necessary
+- Dropdown remains functional
+- No visual glitches or orphaned elements
+
+---
+
+## Visual Specifications
+
+### Layout Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Window Title Bar (drag region)                          │
+├─────────────────────────────────────────────────────────┤
+│ [repo-name ▾] [worktree-badge] [forge-status]          │  ← Sticky Header
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  Scrollable Commit List                                 │
+│                                                         │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Dropdown Structure
+
+```
+┌─────────────────────────────────────┐
+│ ◉ selected-repo                     │  ← Highlighted
+│   /full/path/to/selected-repo     │
+├─────────────────────────────────────┤
+│ 📁 other-repo                    ✕ │
+│   /full/path/to/other-repo        │
+├─────────────────────────────────────┤
+│ 📁 another-repo                  ✕ │
+│   /path/to/another-repo           │
+├─────────────────────────────────────┤
+│ ＋ Add Repository                   │
+│ ⬇ Clone Repository                 │
+└─────────────────────────────────────┘
+```
+
+### Spacing and Sizing
+
+- Header vertical padding: 8px (0.5rem)
+- Header horizontal padding: 24px (1.5rem)
+- Dropdown width: 320px (20rem)
+- Dropdown item padding: 8px vertical, 16px horizontal
+- Dropdown maximum height: 384px (24rem)
+- Icon sizes: 16px (1rem) for list icons, 14px (0.875rem) for chevron
+- Border radius: 6px for buttons, 8px for dropdown
+
+### Interactive States
+
+**Trigger Button:**
+- Default: No background
+- Hover: Subtle muted background
+- Active/Open: Same as hover
+
+**Dropdown Items:**
+- Default: No background
+- Hover: Muted background
+- Selected: Accent background tint (20% opacity)
+
+**Remove Button:**
+- Default: Muted foreground color
+- Hover: Destructive color with light destructive background
+
+---
+
+## Dependencies
+
+- Tooltip component with configurable delay (0ms for instant)
+- Popover/Dropdown component with portal rendering
+- Icon library (folder, checkmark, chevron, plus, download, X)
+- Toast notification system for error feedback
+- System folder picker API
+- Clone dialog component
+
+---
+
+## Out of Scope
+
+- Repository search/filter functionality
+- Repository sorting or ordering
+- Repository grouping or categorization
+- Repository metadata editing
+- Drag-and-drop reordering
+- Repository favorites or pinning
+- Recent repositories section

--- a/docs/feature-specs/02-e2e-testing-infrastructure.md
+++ b/docs/feature-specs/02-e2e-testing-infrastructure.md
@@ -1,0 +1,402 @@
+# Feature Specification: E2E Testing Infrastructure
+
+## Overview
+
+A comprehensive end-to-end testing infrastructure for Teapot using Playwright with Electron. The system enables both automated test execution in CI and AI-agent-assisted test development through an MCP (Model Context Protocol) server and custom driver scripts.
+
+---
+
+## Problem Statement
+
+### User Pain Points
+
+1. **No Automated UI Testing**: Without E2E tests, UI regressions go undetected until users report them. Manual testing is slow and incomplete.
+
+2. **Electron Testing Complexity**: Standard web testing tools don't work with Electron apps. The main process, renderer process, and IPC communication require specialized tooling.
+
+3. **Test Data Isolation**: Git operations modify filesystem state. Tests that share repositories pollute each other, causing flaky failures.
+
+4. **AI Agent Blindness**: AI coding assistants cannot see UI changes they make. Without visual feedback, agents iterate slowly and make mistakes.
+
+5. **CI Environment Differences**: Electron apps require display servers. Linux CI runners fail without proper configuration (Xvfb, sandbox settings).
+
+---
+
+## Solution
+
+A multi-layered testing infrastructure that provides:
+- Playwright Electron integration with composable test fixtures
+- Isolated git repositories per test via temporary directories
+- Visual and programmatic feedback for AI agents via driver scripts
+- CI-compatible configuration with artifact collection on failure
+
+---
+
+## Feature Requirements
+
+### FR-1: Playwright Electron Configuration
+
+Playwright must be configured to launch and control the Electron application.
+
+**Acceptance Criteria:**
+- Configuration file at `playwright.electron.config.ts`
+- Tests run against compiled output (`out/main/index.js`)
+- Build artifact validation before test execution
+- Test timeout of 30 seconds per test
+- Retry count of 2 for flaky test resilience
+- Trace collection on first retry for debugging
+
+### FR-2: Electron App Fixture
+
+A reusable fixture providing isolated Electron app instances for each test.
+
+**Acceptance Criteria:**
+- Each test receives fresh `app` (ElectronApplication) and `page` (Page) objects
+- Isolated `userDataDir` created per test in temp directory
+- User data directory cleaned up after test completion
+- Environment variable `TEAPOT_E2E=1` set to enable test mode
+- Environment variable `TEAPOT_E2E_USER_DATA` points to isolated directory
+- Graceful app shutdown with 5-second timeout and forced kill fallback
+- Sandbox disabled automatically when `CI` environment variable is set
+
+### FR-3: Git Repository Fixture
+
+A fixture that creates and manages temporary git repositories for testing.
+
+**Acceptance Criteria:**
+- Creates isolated git repository in temp directory per test
+- Initial commit with README created automatically
+- Repository cleaned up after test completion
+- Helper methods available:
+  - `repoPath`: Absolute path to repository
+  - `git(command)`: Execute arbitrary git commands
+  - `commitFile(path, content, message)`: Create file and commit
+  - `createFile(path, content)`: Create file without committing
+  - `createBranch(name)`: Create and checkout new branch
+  - `checkout(ref)`: Switch to branch or commit
+- Git user configured (`Test User <test@example.com>`)
+
+### FR-4: Composite Test Fixture
+
+A combined fixture that provides both Electron app and git repository.
+
+**Acceptance Criteria:**
+- Imports as `testWithRepo` from fixtures
+- Provides `{ page, gitRepo }` to test functions
+- Helper function `addRepoToApp(page, repoPath)` to load repository into app
+- Repository loading triggers file dialog bypass via IPC
+- Stack view visibility confirms successful repository loading
+
+### FR-5: Data-TestID Selectors
+
+UI components must have data-testid attributes for reliable test selection.
+
+**Acceptance Criteria:**
+- All interactive elements have `data-testid` attributes
+- Test IDs follow consistent naming convention (kebab-case)
+- Dynamic test IDs use pattern `{component}-{identifier}` (e.g., `branch-badge-main`)
+- Core test IDs documented and stable:
+
+| Component | Test ID |
+|-----------|---------|
+| App container | `app-container` |
+| Topbar | `topbar` |
+| Settings button | `settings-button` |
+| Settings dialog | `settings-dialog` |
+| Repo selector | `repo-selector` |
+| Repo selector button | `repo-selector-button` |
+| Repo dropdown | `repo-dropdown` |
+| Add repo button | `add-repo-button` |
+| Clone repo button | `clone-repo-button` |
+| Stack view | `stack-view` |
+| Sync button | `sync-button` |
+| Empty state (no repo) | `empty-state-no-repo` |
+| Empty state (error) | `empty-state-error` |
+| Error reload button | `error-reload-button` |
+| Commit item | `commit-item` |
+| Branch badge | `branch-badge-{name}` |
+
+### FR-6: CI Integration
+
+E2E tests must run automatically in GitHub Actions.
+
+**Acceptance Criteria:**
+- Workflow defined in `.github/workflows/checks.yml`
+- Tests run on `ubuntu-latest` runner
+- Virtual display provided via `xvfb-run --auto-servernum`
+- Build step (`pnpm build`) precedes test execution
+- Test artifacts (traces, screenshots, videos) uploaded on failure
+- Artifacts accessible from GitHub Actions UI
+
+### FR-7: Test Artifact Collection
+
+Failed tests must produce debugging artifacts.
+
+**Acceptance Criteria:**
+- Artifacts saved to `.context/playwright/` (gitignored)
+- Subdirectories:
+  - `artifacts/`: Screenshots, videos, traces on failure
+  - `html-report/`: Interactive HTML report
+- Traces viewable via `playwright show-trace` command
+- HTML report viewable via `pnpm e2e:trace:open`
+- Clean command (`pnpm e2e:clean`) removes all artifacts
+
+### FR-8: E2E Driver Script
+
+A command-line tool for AI agents to interact with the running application.
+
+**Acceptance Criteria:**
+- Script at `scripts/e2e-agent-driver.ts`
+- Invoked via `pnpm e2e:drive <command> [args]`
+- Single command mode: execute one command and exit
+- Interactive mode: REPL for multiple commands
+- Commands available:
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| `screenshot` | `[path]` | Save screenshot (default: `/tmp/teapot-screenshot.png`) |
+| `snapshot` | | Output accessibility tree as JSON |
+| `click` | `<testid>` | Click element by data-testid |
+| `type` | `<testid> <text>` | Type text into input element |
+| `press` | `<key>` | Press keyboard key (Enter, Escape, Tab) |
+| `wait` | `<testid>` | Wait for element to become visible |
+| `eval` | `<script>` | Evaluate JavaScript in renderer process |
+| `html` | | Output full page HTML |
+
+### FR-9: MCP Server Configuration
+
+Model Context Protocol server for AI-assisted test development.
+
+**Acceptance Criteria:**
+- Configuration file at `.mcp.json`
+- Server command: `npx playwright run-test-mcp-server`
+- Tools exposed to AI agents:
+  - `browser_click`: Click elements
+  - `browser_snapshot`: Get accessibility tree
+  - `generator_write_test`: Generate test code
+- Server available for standard web testing (not Electron-specific)
+
+### FR-10: Agent Definition Files
+
+Pre-configured AI agent prompts for test-related tasks.
+
+**Acceptance Criteria:**
+- Agents defined in `.claude/agents/` directory
+- Agent files:
+  - `playwright-test-planner.md`: Create test plans from requirements
+  - `playwright-test-generator.md`: Generate tests by driving the app
+  - `playwright-test-healer.md`: Fix broken tests using traces
+- Companion prompts in `.claude/prompts/`:
+  - `playwright-test-plan.md`
+  - `playwright-test-generate.md`
+  - `playwright-test-heal.md`
+  - `playwright-test-coverage.md`
+
+### FR-11: NPM Scripts
+
+Package.json scripts for test execution and maintenance.
+
+**Acceptance Criteria:**
+- `pnpm e2e`: Run all E2E tests
+- `pnpm e2e:trace:open`: Open HTML test report
+- `pnpm e2e:clean`: Remove test artifacts and temp directories
+- `pnpm e2e:drive`: Launch agent driver script
+
+---
+
+## Edge Cases
+
+### EC-1: Build Artifacts Missing
+
+**Scenario:** Tests run without prior `pnpm build`.
+
+**Behavior:**
+- Fixture validates `out/main/index.js` exists
+- Clear error message: "Build artifacts missing. Run `pnpm build` before `pnpm e2e`."
+- Test suite fails fast rather than timing out
+
+### EC-2: App Close Timeout
+
+**Scenario:** Electron app doesn't respond to close signal.
+
+**Behavior:**
+- Graceful close attempted first
+- 5-second timeout triggers force kill via SIGKILL
+- Process PID obtained from `electronApp.process().pid`
+- Cleanup continues regardless of close method
+
+### EC-3: CI Linux Sandbox
+
+**Scenario:** Tests run on Linux CI runners that don't support SUID sandbox.
+
+**Behavior:**
+- `CI` environment variable detected
+- `--no-sandbox` flag added to Electron launch args
+- Tests execute without sandbox restrictions
+- Security warning suppressed via `ELECTRON_DISABLE_SECURITY_WARNINGS`
+
+### EC-4: Concurrent Test Pollution
+
+**Scenario:** Multiple tests run in parallel accessing same resources.
+
+**Behavior:**
+- Each test gets unique temp directory via `fs.mkdtempSync`
+- Directory naming pattern: `teapot-e2e-{random}`
+- Git repositories fully isolated
+- User data directories isolated per test
+- Cleanup runs in test teardown
+
+### EC-5: Repository Loading Timeout
+
+**Scenario:** Repository takes longer than expected to load.
+
+**Behavior:**
+- Stack view visibility has 15-second timeout (configurable)
+- Test fails with clear message if timeout exceeded
+- Trace captures state at failure for debugging
+
+### EC-6: Flaky Test Handling
+
+**Scenario:** Test fails intermittently due to timing.
+
+**Behavior:**
+- Retry count of 2 configured in Playwright
+- Trace captured on first retry for investigation
+- Final failure after all retries exhausted
+- Report indicates which attempt failed
+
+### EC-7: Driver Script Without Build
+
+**Scenario:** `pnpm e2e:drive` run without built app.
+
+**Behavior:**
+- Same validation as test fixture
+- Error message instructs to run `pnpm build`
+- Script exits with non-zero code
+
+### EC-8: Interactive Mode Interrupt
+
+**Scenario:** User presses Ctrl+C in interactive driver mode.
+
+**Behavior:**
+- Graceful shutdown initiated
+- Electron app closed properly
+- Temp resources cleaned up
+- Shell returned to user
+
+### EC-9: Unknown Test ID
+
+**Scenario:** Click command targets non-existent testid.
+
+**Behavior:**
+- Playwright's `getByTestId` throws locator error
+- Error message includes testid that wasn't found
+- In interactive mode, prompt returns for next command
+- In single command mode, exits with error
+
+### EC-10: Large Repository Performance
+
+**Scenario:** Test creates repository with 50+ commits or files.
+
+**Behavior:**
+- Tests in `large-repos.spec.ts` cover this scenario
+- Performance metrics captured (load time, frame rate)
+- Explicit timeout increases for known slow operations
+- UI responsiveness verified after loading
+
+---
+
+## Test Coverage Structure
+
+The test suite is organized by functionality:
+
+```
+tests/e2e/
+├── fixtures/
+│   ├── electronApp.ts      # Electron app lifecycle
+│   ├── gitRepo.ts          # Git repository management
+│   └── testWithRepo.ts     # Composite fixture
+├── smoke.spec.ts           # Basic app launch (3 tests)
+├── settings.spec.ts        # Settings dialog (4 tests)
+├── repo-selection.spec.ts  # Repository UI (4 tests)
+├── repo-workflow.spec.ts   # Loading workflow (5 tests)
+├── ui-elements.spec.ts     # Element verification (7 tests)
+├── keyboard-navigation.spec.ts # Accessibility (8 tests)
+├── error-states.spec.ts    # Error handling (9 tests)
+├── edge-cases.spec.ts      # Edge cases (12 tests)
+├── branch-naming.spec.ts   # Branch names (14 tests)
+├── complex-repos.spec.ts   # Complex structures (8 tests)
+└── large-repos.spec.ts     # Performance (13 tests)
+```
+
+Total: 72 test cases across 11 spec files.
+
+---
+
+## Agent Development Workflow
+
+AI agents can use the testing infrastructure for UI development with feedback:
+
+### Workflow Steps
+
+1. **Make Code Changes**: Agent edits component source files
+2. **Build**: Run `pnpm build` to compile changes
+3. **Capture State**: Use driver to screenshot and get accessibility tree
+4. **Verify Changes**: Compare screenshots, analyze tree structure
+5. **Iterate**: Fix issues and repeat until correct
+6. **Write Tests**: Formalize working behavior as E2E tests
+
+### Example Session
+
+```bash
+# Initial state
+pnpm build
+pnpm e2e:drive screenshot /tmp/01-before.png
+pnpm e2e:drive snapshot > /tmp/01-tree.json
+
+# After code changes
+pnpm build
+pnpm e2e:drive screenshot /tmp/02-after.png
+
+# Test interactions
+pnpm e2e:drive click settings-button
+pnpm e2e:drive wait settings-dialog
+pnpm e2e:drive screenshot /tmp/03-dialog.png
+pnpm e2e:drive press Escape
+
+# Verify dialog closed
+pnpm e2e:drive snapshot | grep settings-dialog
+```
+
+---
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `TEAPOT_E2E` | Set to `1` to enable E2E mode (disables updater, enables isolation) |
+| `TEAPOT_E2E_USER_DATA` | Custom userData path for test isolation |
+| `CI` | Triggers `--no-sandbox` flag for Linux CI runners |
+| `PLAYWRIGHT_BROWSERS_PATH` | Shared browser download location across worktrees |
+| `PLAYWRIGHT_WS_PORT` | WebSocket server port for remote driving |
+
+---
+
+## Dependencies
+
+- Playwright (`@playwright/test`) with Electron support
+- Node.js filesystem APIs for temp directory management
+- Git CLI available in PATH for repository fixtures
+- Xvfb for CI display server (Linux only)
+- GitHub Actions for CI workflow
+
+---
+
+## Out of Scope
+
+- Visual regression testing (screenshot comparison)
+- Cross-platform CI (Windows, macOS runners)
+- Performance benchmarking with historical tracking
+- Test parallelization across machines
+- Browser-based testing (Electron only)
+- Mobile/responsive testing

--- a/docs/feature-specs/README.md
+++ b/docs/feature-specs/README.md
@@ -1,0 +1,32 @@
+# Feature Specifications
+
+This directory contains detailed specifications for implemented features in Teapot. These documents serve as the canonical reference for how each feature should behave, enabling:
+
+- **Reimplementation**: Any engineer can rebuild the app using these specs
+- **Testing**: Specifications define acceptance criteria for QA
+- **Onboarding**: New team members can understand feature behavior quickly
+- **Maintenance**: Clear documentation prevents regression during refactoring
+
+## Specification Format
+
+Each feature spec follows a consistent structure:
+
+1. **Overview**: Brief description of the feature
+2. **Problem Statement**: What user pain points the feature addresses
+3. **Solution**: High-level approach taken
+4. **Feature Requirements**: Numbered requirements (FR-1, FR-2, etc.) with acceptance criteria
+5. **Edge Cases**: Numbered edge cases (EC-1, EC-2, etc.) with expected behavior
+6. **Visual Specifications**: Layout, spacing, and interactive states
+7. **Dependencies**: Required components and systems
+8. **Out of Scope**: Explicitly excluded functionality
+
+## Feature Index
+
+| # | Feature | Description |
+|---|---------|-------------|
+| 01 | [Sticky Repository Selector](./01-sticky-repository-selector.md) | Persistent header for repository identification and switching |
+| 02 | [E2E Testing Infrastructure](./02-e2e-testing-infrastructure.md) | Playwright E2E tests with agent-driven development support |
+
+## Related Documentation
+
+- **[Ideas](../ideas/README.md)**: Proposed improvements and future features not yet implemented

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -2,6 +2,8 @@
 
 This directory contains individual idea documents extracted from the `/docs` folder, including post-mortems, proposals, and design documents.
 
+> **Note:** For specifications of already-implemented features, see [Feature Specifications](../feature-specs/README.md).
+
 ## Ideas by Category
 
 ### Architecture & Testing


### PR DESCRIPTION
## Summary

- Add `docs/feature-specs/` directory to document implemented features in detail
- Include first spec: Sticky Repository Selector with full requirements, edge cases, and visual specifications
- Update main README and ideas README with cross-references to the new folder

## Why

Feature specifications enable any engineer to reimplement the app at any point. They serve as canonical references for:
- Testing and QA (acceptance criteria)
- Onboarding new team members
- Preventing regression during refactoring

## Test plan

- [x] Verify all markdown links work correctly
- [ ] Review spec format is clear and comprehensive

🤖 Generated with [Claude Code](https://claude.com/claude-code)