### PR TITLE
feat: multi-worktree conflict awareness

### DIFF
--- a/src/node/adapters/git/interface.ts
+++ b/src/node/adapters/git/interface.ts
@@ -145,7 +145,10 @@ export interface GitAdapter {
    * @param options - Optional settings for worktree listing
    * @returns Array of worktree information
    */
-  listWorktrees(dir: string, options?: { skipDirtyCheck?: boolean }): Promise<WorktreeInfo[]>
+  listWorktrees(
+    dir: string,
+    options?: { skipDirtyCheck?: boolean; skipConflictCheck?: boolean }
+  ): Promise<WorktreeInfo[]>
 
   /**
    * Prune stale worktree references

--- a/src/node/adapters/git/types.ts
+++ b/src/node/adapters/git/types.ts
@@ -265,4 +265,8 @@ export type WorktreeInfo = {
   isStale: boolean
   /** True if the worktree has uncommitted changes */
   isDirty: boolean
+  /** True if a rebase is in progress in this worktree */
+  isRebasing: boolean
+  /** Paths with merge/rebase conflicts (empty if no conflicts) */
+  conflictedFiles: string[]
 }

--- a/src/node/domain/UiStateBuilder.ts
+++ b/src/node/domain/UiStateBuilder.ts
@@ -605,6 +605,8 @@ export class UiStateBuilder {
           status = 'stale'
         } else if (worktreeInfo.path === state.currentWorktreePath) {
           status = 'active'
+        } else if (worktreeInfo.isRebasing && worktreeInfo.conflictedFiles.length > 0) {
+          status = 'conflicted'
         } else if (worktreeInfo.isDirty) {
           status = 'dirty'
         } else {

--- a/src/node/domain/__tests__/RebaseValidator.test.ts
+++ b/src/node/domain/__tests__/RebaseValidator.test.ts
@@ -570,6 +570,8 @@ function createWorktree(path: string, branch: string | null, isDirty: boolean): 
     headSha: 'abc123',
     isMain: path === '/repo',
     isStale: false,
-    isDirty
+    isDirty,
+    isRebasing: false,
+    conflictedFiles: []
   }
 }

--- a/src/node/domain/__tests__/SquashValidator.test.ts
+++ b/src/node/domain/__tests__/SquashValidator.test.ts
@@ -518,6 +518,8 @@ function createWorktree(path: string, branch: string | null, isDirty: boolean): 
     branch,
     isMain: path === '/repo',
     isStale: false,
-    isDirty
+    isDirty,
+    isRebasing: false,
+    conflictedFiles: []
   }
 }

--- a/src/node/operations/RebaseOperation.ts
+++ b/src/node/operations/RebaseOperation.ts
@@ -202,7 +202,7 @@ export class RebaseOperation {
     }
 
     const trunkHeadSha = TrunkResolver.getTrunkHeadSha(repo.branches, repo.commits)
-    const uiState: UiState = { stack, workingTree: [], trunkHeadSha }
+    const uiState: UiState = { stack, workingTree: [], trunkHeadSha, worktrees: repo.worktrees }
 
     return { success: true, uiState }
   }

--- a/src/shared/types/repo.ts
+++ b/src/shared/types/repo.ts
@@ -27,6 +27,10 @@ export type Worktree = {
   isStale: boolean
   /** True if the worktree has uncommitted changes */
   isDirty: boolean
+  /** True if a rebase is in progress in this worktree */
+  isRebasing: boolean
+  /** Paths with merge/rebase conflicts (empty if no conflicts) */
+  conflictedFiles: string[]
 }
 
 export type Branch = {

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -1,4 +1,5 @@
 import type { MergeReadiness } from './git-forge'
+import type { Worktree } from './repo'
 
 export type LocalRepo = {
   path: string
@@ -12,6 +13,8 @@ export type UiState = {
   workingTree: UiWorkingTreeFile[]
   /** The SHA of the current trunk head commit. Used for rebase operations. */
   trunkHeadSha: string
+  /** All worktrees associated with this repository */
+  worktrees: Worktree[]
 }
 
 export type UiStack = {
@@ -134,8 +137,9 @@ export type UiWorktreeBadge = {
    * - 'dirty': Has uncommitted changes (branch is blocked)
    * - 'active': This is the currently active worktree in Teapot
    * - 'stale': Worktree path no longer exists
+   * - 'conflicted': Has merge/rebase conflicts that need resolution
    */
-  status: 'clean' | 'dirty' | 'active' | 'stale'
+  status: 'clean' | 'dirty' | 'active' | 'stale' | 'conflicted'
   /** True if this is the main worktree (original clone location) */
   isMain: boolean
 }

--- a/src/web/components/WorktreeBadge.tsx
+++ b/src/web/components/WorktreeBadge.tsx
@@ -1,4 +1,5 @@
 import type { UiWorktreeBadge } from '@shared/types'
+import { AlertTriangle } from 'lucide-react'
 import React, { memo, useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { useUiStateContext } from '../contexts/UiStateContext'
@@ -14,7 +15,8 @@ import { TreeIcon } from './icons'
  * - Green: currently active worktree
  * - Yellow: worktree has uncommitted changes (branch is blocked)
  * - Gray: worktree is clean (not active)
- * - Red/muted: worktree path no longer exists (stale)
+ * - Orange: worktree path no longer exists (stale - configuration problem)
+ * - Red: worktree has merge conflicts (active work blocker)
  *
  * Double-click to switch to that worktree (only for non-active, non-stale worktrees).
  * Right-click for context menu with worktree actions.
@@ -38,14 +40,16 @@ export const WorktreeBadge = memo(function WorktreeBadge({
     active: 'bg-muted/50 text-muted-foreground/70 border-border/50',
     dirty: 'bg-yellow-500/20 text-yellow-600 border-yellow-500/50',
     clean: 'bg-muted/50 text-muted-foreground/70 border-border/50',
-    stale: 'bg-destructive/20 text-destructive border-destructive/50'
+    stale: 'bg-orange-500/20 text-orange-600 border-orange-500/50',
+    conflicted: 'bg-red-500/20 text-red-600 border-red-500/50'
   }
 
   const statusLabels = {
     active: 'Active worktree',
     dirty: 'Has uncommitted changes',
     clean: 'Clean',
-    stale: 'Path no longer exists'
+    stale: 'Path no longer exists',
+    conflicted: 'Has merge conflicts - click to resolve'
   }
 
   // Can switch only if not active and not stale
@@ -53,6 +57,7 @@ export const WorktreeBadge = memo(function WorktreeBadge({
   const isActive = data.status === 'active'
   const isDirty = data.status === 'dirty'
   const isStale = data.status === 'stale'
+  const isConflicted = data.status === 'conflicted'
 
   const handleDoubleClick = useCallback(() => {
     if (canSwitch) {
@@ -186,7 +191,11 @@ export const WorktreeBadge = memo(function WorktreeBadge({
         onDoubleClick={handleDoubleClick}
       >
         {variant === 'compact' && 'Using worktree '}
-        <TreeIcon className="h-3.5 w-3.5" />
+        {isConflicted ? (
+          <AlertTriangle className="h-3.5 w-3.5" />
+        ) : (
+          <TreeIcon className="h-3.5 w-3.5" />
+        )}
         {displayPath}
         {data.isMain && ' (main)'}
       </span>

--- a/src/web/components/WorktreeConflictBanner.tsx
+++ b/src/web/components/WorktreeConflictBanner.tsx
@@ -1,0 +1,46 @@
+import type { Worktree } from '@shared/types'
+import { AlertTriangle, ArrowRight } from 'lucide-react'
+import React from 'react'
+
+interface WorktreeConflictBannerProps {
+  conflictedWorktrees: Worktree[]
+  onSwitchToWorktree: (worktreePath: string) => void
+}
+
+/**
+ * Non-blocking banner shown when a non-current worktree has merge conflicts.
+ * Allows the user to switch to the conflicted worktree to resolve.
+ */
+export function WorktreeConflictBanner({
+  conflictedWorktrees,
+  onSwitchToWorktree
+}: WorktreeConflictBannerProps): React.JSX.Element | null {
+  if (conflictedWorktrees.length === 0) return null
+
+  const count = conflictedWorktrees.length
+  const firstWorktree = conflictedWorktrees[0]
+
+  return (
+    <div role="alert" className="border-b border-red-500/30 bg-red-500/10 px-4 py-2">
+      <div className="flex items-center justify-between">
+        <div aria-live="polite" className="flex items-center gap-2 text-sm text-red-600">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          <span>
+            {count === 1
+              ? 'A worktree has merge conflicts that need to be resolved'
+              : `${count} worktrees have merge conflicts that need to be resolved`}
+          </span>
+        </div>
+        {count === 1 && (
+          <button
+            onClick={() => onSwitchToWorktree(firstWorktree.path)}
+            className="flex cursor-pointer items-center gap-1 rounded border border-red-500/30 px-2 py-1 text-sm font-medium text-red-600 hover:bg-red-500/10 hover:text-red-700 focus:ring-2 focus:ring-red-500 focus:outline-none"
+          >
+            Switch to resolve
+            <ArrowRight className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/web/main.tsx
+++ b/src/web/main.tsx
@@ -16,7 +16,8 @@ import { UtilityModalsProvider } from './contexts/UtilityModalsContext'
 // eslint-disable-next-line react-refresh/only-export-components
 function AppWithProviders(): React.JSX.Element {
   const { selectedRepo } = useLocalStateContext()
-  const repoPath = selectedRepo?.path ?? null
+  // Use activeWorktreePath when in a worktree, otherwise use the main repo path
+  const repoPath = selectedRepo?.activeWorktreePath ?? selectedRepo?.path ?? null
 
   return (
     <ForgeStateProvider repoPath={repoPath}>


### PR DESCRIPTION
## Summary

- Detect and display rebase conflicts in non-active worktrees (including temp worktrees)
- Show red "conflicted" badge with AlertTriangle icon on worktree indicators
- Display non-blocking red banner when another worktree has conflicts
- Show blocking ConflictResolutionDialog when switching to conflicted worktree
- Support external rebases (rebases started outside Teapot)
- Keep Working Tree section clean - only show current worktree's files

## Changes

**Backend:**

- Add `isRebasing` and `conflictedFiles` fields to `Worktree` and `WorktreeInfo` types
- Enhance `SimpleGitAdapter.listWorktrees()` to detect per-worktree conflict state
- Read rebasing branch name from `rebase-merge/head-name` during detached HEAD state
- Add `skipConflictCheck` option for performance-critical paths

**Frontend:**

- Add `conflicted` status to `UiWorktreeBadge` (red styling)
- Create `WorktreeConflictBanner` component for non-blocking conflict notification
- Add `conflictedWorktrees` and `isCurrentWorktreeConflicted` to `UiStateContext`
- Fix `repoPath` resolution to use `activeWorktreePath` in `main.tsx`
- Support external rebases in `ConflictResolutionDialog` (fallback to repoPath)
- Remove confusing mixing of temp worktree conflicts into main worktree's Working Tree

## Test plan

- [ ] Create a rebase that will conflict in a temp worktree
- [ ] Verify red "conflicted" badge appears on the worktree indicator
- [ ] Verify red banner appears when viewing a different worktree
- [ ] Click "Switch to resolve" and verify ConflictResolutionDialog appears
- [ ] Resolve conflicts and verify badge/banner disappear
- [ ] Test abort flow and verify state is cleaned up properly
- [ ] Test external rebase (started via CLI) shows dialog correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#345 :point\_left:
    - \#361
      - \#362
        - \#363
