### PR TITLE
feat: add new branch creation from existing branches

### DIFF
--- a/src/node/domain/BranchUtils.ts
+++ b/src/node/domain/BranchUtils.ts
@@ -151,7 +151,8 @@ export class BranchUtils {
     const randomNoun = nouns[Math.floor(Math.random() * nouns.length)]
     const randomNumber = Math.floor(Math.random() * 1000)
 
-    return `${prefix}-${randomAdjective}-${randomNoun}-${randomNumber}`
+    const baseName = `${randomAdjective}-${randomNoun}-${randomNumber}`
+    return prefix ? `${prefix}-${baseName}` : baseName
   }
 
   /**

--- a/src/node/handlers/repo.ts
+++ b/src/node/handlers/repo.ts
@@ -553,6 +553,22 @@ const createWorktree: IpcHandlerOf<'createWorktree'> = async (_event, { repoPath
   return result
 }
 
+const createWorktreeWithBranch: IpcHandlerOf<'createWorktreeWithBranch'> = async (
+  _event,
+  { repoPath, sourceBranch, newBranchName, createWorktree, createWorkingCommit }
+) => {
+  const result = await WorktreeOperation.createWithNewBranch(repoPath, sourceBranch, {
+    newBranchName,
+    createWorktree,
+    createWorkingCommit
+  })
+  if (result.success) {
+    const uiState = await UiStateOperation.getUiState(repoPath)
+    return { ...result, uiState }
+  }
+  return result
+}
+
 const getRebaseExecutionPath: IpcHandlerOf<'getRebaseExecutionPath'> = async (
   _event,
   { repoPath }
@@ -624,5 +640,6 @@ export function registerRepoHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.openWorktreeInTerminal, openWorktreeInTerminal)
   ipcMain.handle(IPC_CHANNELS.copyWorktreePath, copyWorktreePath)
   ipcMain.handle(IPC_CHANNELS.createWorktree, createWorktree)
+  ipcMain.handle(IPC_CHANNELS.createWorktreeWithBranch, createWorktreeWithBranch)
   ipcMain.handle(IPC_CHANNELS.getRebaseExecutionPath, getRebaseExecutionPath)
 }

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -151,6 +151,7 @@ export const IPC_CHANNELS = {
   openWorktreeInTerminal: 'openWorktreeInTerminal',
   copyWorktreePath: 'copyWorktreePath',
   createWorktree: 'createWorktree',
+  createWorktreeWithBranch: 'createWorktreeWithBranch',
   // Clone
   cloneRepository: 'cloneRepository',
   getLastClonePath: 'getLastClonePath',
@@ -418,6 +419,26 @@ export interface IpcContract {
   [IPC_CHANNELS.createWorktree]: {
     request: { repoPath: string; branch: string }
     response: { success: boolean; error?: string; worktreePath?: string; uiState?: UiState | null }
+  }
+  [IPC_CHANNELS.createWorktreeWithBranch]: {
+    request: {
+      repoPath: string
+      /** Source branch to base the new branch on */
+      sourceBranch: string
+      /** Name for the new branch (optional - auto-generate if not provided) */
+      newBranchName?: string
+      /** Whether to create a worktree for the new branch (default: true) */
+      createWorktree?: boolean
+      /** Whether to create an empty WIP commit */
+      createWorkingCommit: boolean
+    }
+    response: {
+      success: boolean
+      error?: string
+      worktreePath?: string
+      branchName?: string
+      uiState?: UiState | null
+    }
   }
   [IPC_CHANNELS.cloneRepository]: {
     request: { url: string; targetPath: string; folderName?: string }

--- a/src/web/components/NewBranchDialog.tsx
+++ b/src/web/components/NewBranchDialog.tsx
@@ -1,0 +1,253 @@
+import { Loader2 } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { useUiStateContext } from '../contexts/UiStateContext'
+import { cn } from '../utils/cn'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './Dialog'
+
+interface NewBranchDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sourceBranch: string
+}
+
+const containsInvalidGitBranchChars = (name: string): boolean => {
+  const forbidden = new Set(['~', '^', ':', '?', '*', '[', ']', '\\'])
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) return true
+    if (forbidden.has(name[i])) return true
+  }
+  return false
+}
+
+const validateBranchName = (name: string): string | null => {
+  if (name.startsWith('-')) {
+    return 'Branch name cannot start with a hyphen'
+  }
+  if (name.endsWith('.')) {
+    return 'Branch name cannot end with a dot'
+  }
+  if (name.includes('..')) {
+    return 'Branch name cannot contain ..'
+  }
+  if (containsInvalidGitBranchChars(name)) {
+    return 'Branch name contains invalid characters'
+  }
+  if (name.includes(' ')) {
+    return 'Branch name cannot contain spaces'
+  }
+  return null
+}
+
+// Generate a placeholder name for display (actual generation happens on backend)
+function generatePlaceholderName(): string {
+  const adjectives = ['quick', 'lazy', 'happy', 'calm', 'bold']
+  const nouns = ['fox', 'dog', 'cat', 'owl', 'bear']
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)]
+  const noun = nouns[Math.floor(Math.random() * nouns.length)]
+  const num = Math.floor(Math.random() * 100)
+  return `${adj}-${noun}-${num}`
+}
+
+export function NewBranchDialog({
+  open,
+  onOpenChange,
+  sourceBranch
+}: NewBranchDialogProps): React.JSX.Element {
+  const { repoPath, createWorktreeWithBranch } = useUiStateContext()
+
+  const [branchName, setBranchName] = useState('')
+  const [createWorktree, setCreateWorktree] = useState(true)
+  const [createWorkingCommit, setCreateWorkingCommit] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Generate placeholder on dialog open
+  const placeholderName = useMemo(() => (open ? generatePlaceholderName() : ''), [open])
+
+  // Reset form state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setBranchName('')
+      setCreateWorktree(true)
+      setCreateWorkingCommit(false)
+      setError(null)
+    }
+  }, [open])
+
+  const trimmedName = branchName.trim()
+  const validationError = trimmedName ? validateBranchName(trimmedName) : null
+
+  const handleCreate = useCallback(async () => {
+    if (!repoPath) return
+
+    if (trimmedName && validationError) {
+      setError(validationError)
+      return
+    }
+
+    setIsCreating(true)
+    setError(null)
+
+    try {
+      const result = await createWorktreeWithBranch({
+        sourceBranch,
+        newBranchName: trimmedName || undefined,
+        createWorktree,
+        createWorkingCommit: createWorktree && createWorkingCommit
+      })
+
+      if (result.success) {
+        // Close dialog immediately
+        onOpenChange(false)
+
+        // Show success toast
+        if (createWorktree && result.worktreePath) {
+          toast.success('Branch and worktree created', {
+            description: `Branch ${result.branchName} at ${result.worktreePath}`
+          })
+        } else {
+          toast.success('Branch created', {
+            description: `Branch ${result.branchName} created from ${sourceBranch}`
+          })
+        }
+      } else {
+        setError(result.error || 'Failed to create branch')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create branch')
+    } finally {
+      setIsCreating(false)
+    }
+  }, [
+    repoPath,
+    sourceBranch,
+    trimmedName,
+    validationError,
+    createWorktree,
+    createWorkingCommit,
+    createWorktreeWithBranch,
+    onOpenChange
+  ])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !isCreating && !validationError) {
+        e.preventDefault()
+        handleCreate()
+      }
+    },
+    [isCreating, validationError, handleCreate]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="px-5 py-5 sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>New Branch</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Source branch info */}
+          <p className="text-muted-foreground text-sm">
+            Creating branch from{' '}
+            <code className="bg-muted rounded px-1 py-0.5 text-xs">{sourceBranch}</code>
+          </p>
+
+          {/* Branch name input */}
+          <div className="space-y-2">
+            <label htmlFor="branch-name" className="text-sm font-medium">
+              Branch Name
+            </label>
+            <input
+              id="branch-name"
+              type="text"
+              value={branchName}
+              onChange={(e) => {
+                setBranchName(e.target.value)
+                setError(null)
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholderName}
+              disabled={isCreating}
+              autoFocus
+              className="border-border bg-background placeholder:text-muted-foreground focus:border-foreground flex w-full rounded-md border px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            {(error || validationError) && (
+              <p className="text-destructive text-xs">{error || validationError}</p>
+            )}
+            {!branchName && !error && (
+              <p className="text-muted-foreground text-xs">
+                Leave empty to auto-generate: {placeholderName}
+              </p>
+            )}
+          </div>
+
+          {/* Create worktree checkbox */}
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              checked={createWorktree}
+              onChange={(e) => setCreateWorktree(e.target.checked)}
+              disabled={isCreating}
+              className="mt-1"
+            />
+            <div>
+              <span className="text-sm font-medium">Create worktree</span>
+              <p className="text-muted-foreground mt-0.5 text-xs">
+                Check out the branch in a new working directory
+              </p>
+            </div>
+          </label>
+
+          {/* Worktree-specific options (only shown when creating worktree) */}
+          {createWorktree && (
+            <div className="border-muted space-y-3 border-l-2 pl-4">
+              {/* Working commit checkbox */}
+              <label className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={createWorkingCommit}
+                  onChange={(e) => setCreateWorkingCommit(e.target.checked)}
+                  disabled={isCreating}
+                  className="mt-1"
+                />
+                <div>
+                  <span className="text-sm font-medium">Create working commit</span>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    Add an empty &quot;WIP&quot; commit as a starting point
+                  </p>
+                </div>
+              </label>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            disabled={isCreating}
+            className="border-border bg-muted text-foreground hover:bg-muted/80 rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={isCreating || !!validationError}
+            className={cn(
+              'bg-accent text-accent-foreground hover:bg-accent/90 flex items-center gap-2 rounded px-3 py-1.5 text-sm transition-colors',
+              (isCreating || validationError) && 'cursor-not-allowed opacity-50'
+            )}
+          >
+            {isCreating && <Loader2 className="h-4 w-4 animate-spin" />}
+            {isCreating ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/web/contexts/UiStateContext.tsx
+++ b/src/web/contexts/UiStateContext.tsx
@@ -64,6 +64,17 @@ interface UiStateContextValue {
   createWorktree: (params: {
     branch: string
   }) => Promise<{ success: boolean; worktreePath?: string }>
+  createWorktreeWithBranch: (params: {
+    sourceBranch: string
+    newBranchName?: string
+    createWorktree?: boolean
+    createWorkingCommit: boolean
+  }) => Promise<{
+    success: boolean
+    error?: string
+    worktreePath?: string
+    branchName?: string
+  }>
   removeWorktree: (params: {
     worktreePath: string
     force?: boolean
@@ -112,6 +123,7 @@ const DEFAULT_UI_STATE_CONTEXT: UiStateContextValue = {
   syncTrunk: async () => {},
   switchWorktree: async () => {},
   createWorktree: async () => ({ success: false }),
+  createWorktreeWithBranch: async () => ({ success: false }),
   removeWorktree: async () => ({ success: false }),
   isWorkingTreeDirty: false,
   isRebasingWithConflicts: false,
@@ -612,6 +624,33 @@ export function UiStateProvider({
     [repoPath]
   )
 
+  const createWorktreeWithBranch = useCallback(
+    async (params: {
+      sourceBranch: string
+      newBranchName?: string
+      createWorktree?: boolean
+      createWorkingCommit: boolean
+    }): Promise<{
+      success: boolean
+      error?: string
+      worktreePath?: string
+      branchName?: string
+    }> => {
+      if (!repoPath) return { success: false, error: 'No repository selected' }
+      const result = await window.api.createWorktreeWithBranch({ repoPath, ...params })
+      if (result.success && result.uiState) {
+        setUiState(result.uiState)
+      }
+      return {
+        success: result.success,
+        error: result.error,
+        worktreePath: result.worktreePath,
+        branchName: result.branchName
+      }
+    },
+    [repoPath]
+  )
+
   const removeWorktree = useCallback(
     async (params: { worktreePath: string; force?: boolean }): Promise<{ success: boolean }> => {
       if (!repoPath) return { success: false }
@@ -810,6 +849,7 @@ export function UiStateProvider({
       syncTrunk,
       switchWorktree,
       createWorktree,
+      createWorktreeWithBranch,
       removeWorktree,
       isWorkingTreeDirty,
       isRebasingWithConflicts,
@@ -850,6 +890,7 @@ export function UiStateProvider({
       syncTrunk,
       switchWorktree,
       createWorktree,
+      createWorktreeWithBranch,
       removeWorktree,
       isWorkingTreeDirty,
       isRebasingWithConflicts,


### PR DESCRIPTION
## Summary

- Adds "New branch from..." option in branch context menu to create new branches from any existing branch
- New branch creation dialog with options for worktree and working commit
- Auto-generates random branch names if left empty (e.g., `calm-fox-42`)
- Improved worktree naming to use `wt-<branch-name>` format

## Changes

- **NewBranchDialog**: New dialog component for branch creation with options
- **BranchBadge**: Added "Create worktree" (for existing branch) and "New branch from..." context menu items
- **WorktreeOperation**: New `createWithNewBranch()` method with rollback on failure
- **BranchUtils**: Fixed `generateRandomBranchName` to handle empty prefix
- **IPC**: Added `createWorktreeWithBranch` channel
- **UiStateContext**: Added `createWorktreeWithBranch` method

## Test plan

- [ ] Right-click any branch → "New branch from..." → Dialog opens
- [ ] Enter branch name → Create → Branch and worktree created
- [ ] Leave name empty → Create → Random name generated
- [ ] Enable "Create working commit" → Verify empty WIP commit created
- [ ] Uncheck "Create worktree" → Only branch created, no worktree

🤖 Generated with [Claude Code](https://claude.ai/code)

- `main` <!-- branch-stack -->
  - \#346 :point\_left:
    - \#347
