### PR TITLE
feat: add per-repo worktree initialization configuration

### DIFF
--- a/src/node/handlers/repo.ts
+++ b/src/node/handlers/repo.ts
@@ -555,18 +555,30 @@ const createWorktree: IpcHandlerOf<'createWorktree'> = async (_event, { repoPath
 
 const createWorktreeWithBranch: IpcHandlerOf<'createWorktreeWithBranch'> = async (
   _event,
-  { repoPath, sourceBranch, newBranchName, createWorktree, createWorkingCommit }
+  { repoPath, sourceBranch, newBranchName, createWorktree, createWorkingCommit, runInitialization }
 ) => {
   const result = await WorktreeOperation.createWithNewBranch(repoPath, sourceBranch, {
     newBranchName,
     createWorktree,
-    createWorkingCommit
+    createWorkingCommit,
+    runInitialization
   })
   if (result.success) {
     const uiState = await UiStateOperation.getUiState(repoPath)
     return { ...result, uiState }
   }
   return result
+}
+
+const getWorktreeInitConfig: IpcHandlerOf<'getWorktreeInitConfig'> = (_event, { repoPath }) => {
+  return configStore.getWorktreeInitConfig(repoPath)
+}
+
+const setWorktreeInitConfig: IpcHandlerOf<'setWorktreeInitConfig'> = (
+  _event,
+  { repoPath, config }
+) => {
+  configStore.setWorktreeInitConfig(repoPath, config)
 }
 
 const getRebaseExecutionPath: IpcHandlerOf<'getRebaseExecutionPath'> = async (
@@ -641,5 +653,7 @@ export function registerRepoHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.copyWorktreePath, copyWorktreePath)
   ipcMain.handle(IPC_CHANNELS.createWorktree, createWorktree)
   ipcMain.handle(IPC_CHANNELS.createWorktreeWithBranch, createWorktreeWithBranch)
+  ipcMain.handle(IPC_CHANNELS.getWorktreeInitConfig, getWorktreeInitConfig)
+  ipcMain.handle(IPC_CHANNELS.setWorktreeInitConfig, setWorktreeInitConfig)
   ipcMain.handle(IPC_CHANNELS.getRebaseExecutionPath, getRebaseExecutionPath)
 }

--- a/src/node/store.ts
+++ b/src/node/store.ts
@@ -3,9 +3,11 @@ import type {
   FileLogLevel,
   LocalRepo,
   RebaseIntent,
-  RebaseState
+  RebaseState,
+  WorktreeInitConfig
 } from '@shared/types'
 import type { GitForgeState, MergeStrategy } from '@shared/types/git-forge'
+import { DEFAULT_WORKTREE_INIT_CONFIG } from '@shared/types/repo'
 import Store from 'electron-store'
 
 // Rebase session type - defined here to avoid circular imports with SessionService
@@ -39,6 +41,8 @@ interface StoreSchema {
   debugLoggingEnabled?: boolean
   rebaseSessions: Record<string, StoredRebaseSession>
   forgeStateCache: Record<string, CachedForgeState>
+  /** Per-repo worktree initialization configuration, keyed by repoPath */
+  worktreeInitConfigs: Record<string, WorktreeInitConfig>
 }
 
 export class ConfigStore {
@@ -50,7 +54,8 @@ export class ConfigStore {
       defaults: {
         repos: [],
         rebaseSessions: {},
-        forgeStateCache: {}
+        forgeStateCache: {},
+        worktreeInitConfigs: {}
       }
     })
   }
@@ -271,6 +276,35 @@ export class ConfigStore {
     const cache = this.store.get('forgeStateCache', {})
     delete cache[repoPath]
     this.store.set('forgeStateCache', cache)
+  }
+
+  // Worktree initialization config methods
+
+  /**
+   * Get worktree initialization config for a repository.
+   * Returns default config if none is set.
+   */
+  getWorktreeInitConfig(repoPath: string): WorktreeInitConfig {
+    const configs = this.store.get('worktreeInitConfigs', {})
+    return configs[repoPath] ?? DEFAULT_WORKTREE_INIT_CONFIG
+  }
+
+  /**
+   * Set worktree initialization config for a repository.
+   */
+  setWorktreeInitConfig(repoPath: string, config: WorktreeInitConfig): void {
+    const configs = this.store.get('worktreeInitConfigs', {})
+    configs[repoPath] = config
+    this.store.set('worktreeInitConfigs', configs)
+  }
+
+  /**
+   * Delete worktree initialization config for a repository.
+   */
+  deleteWorktreeInitConfig(repoPath: string): void {
+    const configs = this.store.get('worktreeInitConfigs', {})
+    delete configs[repoPath]
+    this.store.set('worktreeInitConfigs', configs)
   }
 }
 

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -1,6 +1,7 @@
 import { IpcMainInvokeEvent } from 'electron'
 import type { ForgeStateResult, MergeStrategy } from './git-forge'
 import type { RebaseState, WorktreeConflict } from './rebase'
+import type { WorktreeInitConfig } from './repo'
 import type { BranchChoice, SquashPreview, SquashResult } from './squash'
 import type { LocalRepo, UiState } from './ui'
 
@@ -152,6 +153,8 @@ export const IPC_CHANNELS = {
   copyWorktreePath: 'copyWorktreePath',
   createWorktree: 'createWorktree',
   createWorktreeWithBranch: 'createWorktreeWithBranch',
+  getWorktreeInitConfig: 'getWorktreeInitConfig',
+  setWorktreeInitConfig: 'setWorktreeInitConfig',
   // Clone
   cloneRepository: 'cloneRepository',
   getLastClonePath: 'getLastClonePath',
@@ -431,6 +434,8 @@ export interface IpcContract {
       createWorktree?: boolean
       /** Whether to create an empty WIP commit */
       createWorkingCommit: boolean
+      /** Whether to run initialization (copy files, run commands) */
+      runInitialization: boolean
     }
     response: {
       success: boolean
@@ -439,6 +444,14 @@ export interface IpcContract {
       branchName?: string
       uiState?: UiState | null
     }
+  }
+  [IPC_CHANNELS.getWorktreeInitConfig]: {
+    request: { repoPath: string }
+    response: WorktreeInitConfig
+  }
+  [IPC_CHANNELS.setWorktreeInitConfig]: {
+    request: { repoPath: string; config: WorktreeInitConfig }
+    response: void
   }
   [IPC_CHANNELS.cloneRepository]: {
     request: { url: string; targetPath: string; folderName?: string }

--- a/src/shared/types/repo.ts
+++ b/src/shared/types/repo.ts
@@ -29,6 +29,44 @@ export type Worktree = {
   isDirty: boolean
 }
 
+/**
+ * Per-repository worktree initialization configuration.
+ * Stored in the main config store, keyed by repoPath.
+ */
+export type WorktreeInitConfig = {
+  /** Gitignored files to copy from main worktree to new worktrees */
+  filesToCopy: string[]
+  /** Commands to run after worktree creation (in order) */
+  setupCommands: string[]
+  /** Whether to create an empty "WIP" commit for new branches by default */
+  createWorkingCommit: boolean
+}
+
+/** Default configuration for repos without custom settings */
+export const DEFAULT_WORKTREE_INIT_CONFIG: WorktreeInitConfig = {
+  filesToCopy: [],
+  setupCommands: [],
+  createWorkingCommit: false
+}
+
+/**
+ * Result of worktree initialization (file copies and command runs)
+ */
+export type WorktreeInitializationResult = {
+  /** Files that were successfully copied */
+  filesCopied: string[]
+  /** Files that could not be copied */
+  filesSkipped: Array<{ file: string; reason: string }>
+  /** Results of running setup commands */
+  commandResults: Array<{
+    command: string
+    success: boolean
+    output?: string
+    error?: string
+    durationMs: number
+  }>
+}
+
 export type Branch = {
   ref: string
   isTrunk: boolean

--- a/src/web/components/RepositorySettings.tsx
+++ b/src/web/components/RepositorySettings.tsx
@@ -1,0 +1,205 @@
+import { log } from '@shared/logger'
+import type { WorktreeInitConfig } from '@shared/types/repo'
+import { DEFAULT_WORKTREE_INIT_CONFIG } from '@shared/types/repo'
+import { X } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+
+interface RepositorySettingsProps {
+  repoPath: string
+}
+
+export function RepositorySettings({ repoPath }: RepositorySettingsProps): React.JSX.Element {
+  const [config, setConfig] = useState<WorktreeInitConfig>(DEFAULT_WORKTREE_INIT_CONFIG)
+  const [isLoading, setIsLoading] = useState(true)
+  const [newFile, setNewFile] = useState('')
+  const [newCommand, setNewCommand] = useState('')
+
+  // Load config on mount
+  useEffect(() => {
+    setIsLoading(true)
+    window.api
+      .getWorktreeInitConfig({ repoPath })
+      .then((loadedConfig) => {
+        setConfig(loadedConfig)
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }, [repoPath])
+
+  async function updateConfig(updates: Partial<WorktreeInitConfig>): Promise<void> {
+    const newConfig = { ...config, ...updates }
+    setConfig(newConfig)
+    try {
+      await window.api.setWorktreeInitConfig({ repoPath, config: newConfig })
+    } catch (error) {
+      log.error('Failed to save worktree init config:', error)
+      setConfig(config) // Revert optimistic update
+    }
+  }
+
+  function addItem(
+    value: string,
+    list: string[],
+    key: 'filesToCopy' | 'setupCommands',
+    clear: () => void
+  ): void {
+    const trimmed = value.trim()
+    if (!trimmed || list.includes(trimmed)) {
+      clear()
+      return
+    }
+    updateConfig({ [key]: [...list, trimmed] })
+    clear()
+  }
+
+  function removeItem(index: number, list: string[], key: 'filesToCopy' | 'setupCommands'): void {
+    updateConfig({ [key]: list.filter((_, i) => i !== index) })
+  }
+
+  const addFile = () => addItem(newFile, config.filesToCopy, 'filesToCopy', () => setNewFile(''))
+  const addCommand = () =>
+    addItem(newCommand, config.setupCommands, 'setupCommands', () => setNewCommand(''))
+  const removeFile = (index: number) => removeItem(index, config.filesToCopy, 'filesToCopy')
+  const removeCommand = (index: number) => removeItem(index, config.setupCommands, 'setupCommands')
+
+  if (isLoading) {
+    return <div className="text-muted-foreground py-8 text-center text-sm">Loading...</div>
+  }
+
+  const hasConfig = config.filesToCopy.length > 0 || config.setupCommands.length > 0
+
+  return (
+    <div className="space-y-6">
+      {/* Introduction */}
+      {!hasConfig && (
+        <div className="bg-muted/30 text-muted-foreground rounded-md p-3 text-sm">
+          Configure worktree initialization to automatically copy files and run commands when
+          creating new worktrees.
+        </div>
+      )}
+
+      {/* Files to copy section */}
+      <div className="space-y-3">
+        <div>
+          <h4 className="text-sm font-medium">Files to Copy</h4>
+          <p className="text-muted-foreground mt-1 text-xs">
+            These files will be copied from the main worktree to new worktrees (e.g., .env,
+            config/local.json).
+          </p>
+        </div>
+
+        {config.filesToCopy.length > 0 && (
+          <div className="space-y-1.5">
+            {config.filesToCopy.map((file, index) => (
+              <div
+                key={file}
+                className="bg-muted/30 border-input flex items-center justify-between gap-2 rounded border px-3 py-2"
+              >
+                <code className="text-foreground text-xs">{file}</code>
+                <button
+                  type="button"
+                  onClick={() => removeFile(index)}
+                  className="text-muted-foreground hover:text-destructive transition-colors"
+                  aria-label={`Remove ${file}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newFile}
+            onChange={(e) => setNewFile(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && addFile()}
+            placeholder=".env, .env.local, config/local.json..."
+            className="border-input bg-background placeholder:text-muted-foreground focus:border-foreground flex-1 rounded-md border px-3 py-2 text-sm outline-none"
+          />
+          <button
+            type="button"
+            onClick={addFile}
+            disabled={!newFile.trim()}
+            className="border-input bg-muted text-foreground hover:bg-muted/80 rounded border px-3 py-2 text-sm transition-colors disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Setup commands section */}
+      <div className="space-y-3">
+        <div>
+          <h4 className="text-sm font-medium">Setup Commands</h4>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Commands to run after creating a worktree (e.g., install dependencies). Commands run in
+            background with a 5-minute timeout.
+          </p>
+        </div>
+
+        {config.setupCommands.length > 0 && (
+          <div className="space-y-1.5">
+            {config.setupCommands.map((command, index) => (
+              <div
+                key={command}
+                className="bg-muted/30 border-input flex items-center justify-between gap-2 rounded border px-3 py-2"
+              >
+                <code className="text-foreground font-mono text-xs">{command}</code>
+                <button
+                  type="button"
+                  onClick={() => removeCommand(index)}
+                  className="text-muted-foreground hover:text-destructive transition-colors"
+                  aria-label={`Remove ${command}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newCommand}
+            onChange={(e) => setNewCommand(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && addCommand()}
+            placeholder="pnpm install, npm ci, yarn..."
+            className="border-input bg-background placeholder:text-muted-foreground focus:border-foreground flex-1 rounded-md border px-3 py-2 font-mono text-sm outline-none"
+          />
+          <button
+            type="button"
+            onClick={addCommand}
+            disabled={!newCommand.trim()}
+            className="border-input bg-muted text-foreground hover:bg-muted/80 rounded border px-3 py-2 text-sm transition-colors disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Default options section */}
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium">Default Options</h4>
+
+        <label className="flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={config.createWorkingCommit}
+            onChange={(e) => updateConfig({ createWorkingCommit: e.target.checked })}
+            className="border-input bg-background h-4 w-4 shrink-0 rounded border accent-current disabled:cursor-not-allowed disabled:opacity-50"
+          />
+          <div>
+            <span className="text-sm">Create working commit by default</span>
+            <p className="text-muted-foreground text-xs">
+              New worktrees will start with an empty &quot;WIP&quot; commit
+            </p>
+          </div>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/src/web/components/SettingsDialog.tsx
+++ b/src/web/components/SettingsDialog.tsx
@@ -4,7 +4,10 @@ import type { MergeStrategy } from '@shared/types/git-forge'
 import { ExternalLink } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { useTheme } from '../contexts/ThemeContext'
+import { useUiStateContext } from '../contexts/UiStateContext'
+import { cn } from '../utils/cn'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './Dialog'
+import { RepositorySettings } from './RepositorySettings'
 
 const FILE_LOG_LEVEL_OPTIONS: ReadonlyArray<{
   value: FileLogLevel
@@ -22,8 +25,12 @@ interface SettingsDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+type SettingsTab = 'general' | 'repository'
+
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps): React.JSX.Element {
   const { preference, setPreference } = useTheme()
+  const { repoPath } = useUiStateContext()
+  const [activeTab, setActiveTab] = useState<SettingsTab>('general')
   const [pat, setPat] = useState('')
   const [editor, setEditor] = useState('')
   const [mergeStrategy, setMergeStrategy] = useState<MergeStrategy>('rebase')
@@ -34,6 +41,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps): Rea
   useEffect(() => {
     if (open) {
       loadSettings()
+    } else {
+      setActiveTab('general')
     }
   }, [open])
 
@@ -110,164 +119,203 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps): Rea
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]" data-testid="settings-dialog">
+      <DialogContent className="sm:max-w-[475px]" data-testid="settings-dialog">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>
-        <div className="grid gap-6 py-4">
-          <div className="space-y-2">
-            <label htmlFor="theme-select" className="text-sm leading-none font-medium">
-              Appearance
-            </label>
-            <p className="text-muted-foreground text-sm">Choose your preferred color scheme</p>
-            <select
-              id="theme-select"
-              value={preference}
-              onChange={(e) => setPreference(e.target.value as 'light' | 'dark' | 'system')}
-              className="border-input bg-background ring-offset-background focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            >
-              <option value="system">System (follow OS preference)</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </div>
 
-          <div className="space-y-2">
-            <h4 className="text-sm leading-none font-medium">Preferred Editor</h4>
-            <p className="text-muted-foreground text-sm">
-              Command to open worktrees in your editor. Leave empty for VS Code.
-            </p>
-            <input
-              type="text"
-              value={editor}
-              onChange={handleEditorChange}
-              disabled={isLoading}
-              placeholder="code, cursor, subl, vim..."
-              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <h4 className="text-sm leading-none font-medium">GitHub Personal Access Token</h4>
-            <p className="text-muted-foreground text-sm">
-              Create or revoke your token in{' '}
-              <a
-                href="https://github.com/settings/tokens"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:underline"
-              >
-                https://github.com/settings/tokens
-              </a>
-            </p>
-            <p className="text-muted-foreground text-xs">
-              This PAT needs &quot;repo&quot; scope to function properly.
-            </p>
-            <input
-              type="password"
-              value={pat}
-              onChange={handlePatChange}
-              disabled={isLoading}
-              placeholder="ghp_..."
-              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <h4 className="text-sm leading-none font-medium">PR Merge Strategy</h4>
-            <p className="text-muted-foreground text-sm">
-              How pull requests are merged when using Ship It
-            </p>
-            <select
-              value={mergeStrategy}
-              onChange={handleMergeStrategyChange}
-              disabled={isLoading}
-              className="border-input bg-background ring-offset-background focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <option value="rebase">Rebase & Merge</option>
-              <option value="squash">Squash & Merge</option>
-              <option value="merge">Merge</option>
-              <option value="fast-forward">Fast-forward (no merge commit)</option>
-            </select>
-          </div>
-
-          <div className="space-y-3">
-            <h4 className="text-sm leading-none font-medium">Debug Logging</h4>
-            <div className="text-muted-foreground text-sm">
-              <p>Capture logs for troubleshooting</p>
-              <p className="mt-1">
-                Saved per repository in{' '}
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const result = await window.api.showDebugLogFile()
-                    if (!result.success && result.error) {
-                      log.warn('Could not show debug log file:', result.error)
-                    }
-                  }}
-                  className="bg-muted inline-flex items-center gap-1 rounded px-1 py-0.5 font-mono hover:underline"
-                >
-                  .git/teapot-debug.log
-                  <ExternalLink className="h-3 w-3" />
-                </button>
-              </p>
-            </div>
-            <div className="space-y-2">
-              <div
-                className="bg-muted/30 flex w-full rounded-lg p-1"
-                role="radiogroup"
-                aria-label="Log level"
-              >
-                {FILE_LOG_LEVEL_OPTIONS.map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={fileLogLevel === option.value}
-                    disabled={isLoading}
-                    onClick={() => handleFileLogLevelChange(option.value)}
-                    className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                      fileLogLevel === option.value
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
-              <p className="text-muted-foreground min-h-[1.25rem] text-xs">
-                {FILE_LOG_LEVEL_OPTIONS.find((o) => o.value === fileLogLevel)?.description}
-              </p>
-            </div>
-          </div>
-
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <h4 className="text-sm leading-none font-medium">Parallel Worktree Mode</h4>
-              <span className="rounded bg-yellow-500/20 px-1.5 py-0.5 text-xs text-yellow-600 dark:text-yellow-400">
-                Experimental
-              </span>
-            </div>
-            <div className="text-muted-foreground text-sm">
-              <p>Run rebases in a temporary worktree to preserve uncommitted changes</p>
-            </div>
-            <label className="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                checked={useParallelWorktree}
-                onChange={(e) => handleParallelWorktreeChange(e.target.checked)}
-                disabled={isLoading}
-                className="border-input bg-background h-4 w-4 rounded border accent-current disabled:cursor-not-allowed disabled:opacity-50"
-              />
-              <span className="text-sm">Enable parallel worktree mode</span>
-            </label>
-            <p className="text-muted-foreground text-xs">
-              Warning: This feature may cause stuck rebases or disappearing dialogs. Disable if you
-              experience issues.
-            </p>
-          </div>
+        {/* Tab navigation */}
+        <div className="border-border flex border-b">
+          <button
+            type="button"
+            onClick={() => setActiveTab('general')}
+            className={cn(
+              'px-4 py-2 text-sm font-medium transition-colors',
+              activeTab === 'general'
+                ? 'border-accent text-foreground border-b-2'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            General
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('repository')}
+            disabled={!repoPath}
+            className={cn(
+              'px-4 py-2 text-sm font-medium transition-colors',
+              activeTab === 'repository'
+                ? 'border-accent text-foreground border-b-2'
+                : 'text-muted-foreground hover:text-foreground',
+              !repoPath && 'cursor-not-allowed opacity-50'
+            )}
+          >
+            Repository
+          </button>
         </div>
+
+        {activeTab === 'general' && (
+          <div className="grid gap-6 py-4">
+            <div className="space-y-2">
+              <label htmlFor="theme-select" className="text-sm leading-none font-medium">
+                Appearance
+              </label>
+              <p className="text-muted-foreground text-sm">Choose your preferred color scheme</p>
+              <select
+                id="theme-select"
+                value={preference}
+                onChange={(e) => setPreference(e.target.value as 'light' | 'dark' | 'system')}
+                className="border-input bg-background ring-offset-background focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                <option value="system">System (follow OS preference)</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <h4 className="text-sm leading-none font-medium">Preferred Editor</h4>
+              <p className="text-muted-foreground text-sm">
+                Command to open worktrees in your editor. Leave empty for VS Code.
+              </p>
+              <input
+                type="text"
+                value={editor}
+                onChange={handleEditorChange}
+                disabled={isLoading}
+                placeholder="code, cursor, subl, vim..."
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <h4 className="text-sm leading-none font-medium">GitHub Personal Access Token</h4>
+              <p className="text-muted-foreground text-sm">
+                Create or revoke your token in{' '}
+                <a
+                  href="https://github.com/settings/tokens"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  https://github.com/settings/tokens
+                </a>
+              </p>
+              <p className="text-muted-foreground text-xs">
+                This PAT needs &quot;repo&quot; scope to function properly.
+              </p>
+              <input
+                type="password"
+                value={pat}
+                onChange={handlePatChange}
+                disabled={isLoading}
+                placeholder="ghp_..."
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <h4 className="text-sm leading-none font-medium">PR Merge Strategy</h4>
+              <p className="text-muted-foreground text-sm">
+                How pull requests are merged when using Ship It
+              </p>
+              <select
+                value={mergeStrategy}
+                onChange={handleMergeStrategyChange}
+                disabled={isLoading}
+                className="border-input bg-background ring-offset-background focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="rebase">Rebase & Merge</option>
+                <option value="squash">Squash & Merge</option>
+                <option value="merge">Merge</option>
+                <option value="fast-forward">Fast-forward (no merge commit)</option>
+              </select>
+            </div>
+
+            <div className="space-y-3">
+              <h4 className="text-sm leading-none font-medium">Debug Logging</h4>
+              <div className="text-muted-foreground text-sm">
+                <p>Capture logs for troubleshooting</p>
+                <p className="mt-1">
+                  Saved per repository in{' '}
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      const result = await window.api.showDebugLogFile()
+                      if (!result.success && result.error) {
+                        log.warn('Could not show debug log file:', result.error)
+                      }
+                    }}
+                    className="bg-muted inline-flex items-center gap-1 rounded px-1 py-0.5 font-mono hover:underline"
+                  >
+                    .git/teapot-debug.log
+                    <ExternalLink className="h-3 w-3" />
+                  </button>
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div
+                  className="bg-muted/30 flex w-full rounded-lg p-1"
+                  role="radiogroup"
+                  aria-label="Log level"
+                >
+                  {FILE_LOG_LEVEL_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      role="radio"
+                      aria-checked={fileLogLevel === option.value}
+                      disabled={isLoading}
+                      onClick={() => handleFileLogLevelChange(option.value)}
+                      className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                        fileLogLevel === option.value
+                          ? 'bg-background text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-muted-foreground min-h-[1.25rem] text-xs">
+                  {FILE_LOG_LEVEL_OPTIONS.find((o) => o.value === fileLogLevel)?.description}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h4 className="text-sm leading-none font-medium">Parallel Worktree Mode</h4>
+                <span className="rounded bg-yellow-500/20 px-1.5 py-0.5 text-xs text-yellow-600 dark:text-yellow-400">
+                  Experimental
+                </span>
+              </div>
+              <div className="text-muted-foreground text-sm">
+                <p>Run rebases in a temporary worktree to preserve uncommitted changes</p>
+              </div>
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={useParallelWorktree}
+                  onChange={(e) => handleParallelWorktreeChange(e.target.checked)}
+                  disabled={isLoading}
+                  className="border-input bg-background h-4 w-4 rounded border accent-current disabled:cursor-not-allowed disabled:opacity-50"
+                />
+                <span className="text-sm">Enable parallel worktree mode</span>
+              </label>
+              <p className="text-muted-foreground text-xs">
+                Warning: This feature may cause stuck rebases or disappearing dialogs. Disable if
+                you experience issues.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'repository' && repoPath && (
+          <div className="py-4">
+            <RepositorySettings repoPath={repoPath} />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/web/contexts/UiStateContext.tsx
+++ b/src/web/contexts/UiStateContext.tsx
@@ -69,6 +69,7 @@ interface UiStateContextValue {
     newBranchName?: string
     createWorktree?: boolean
     createWorkingCommit: boolean
+    runInitialization: boolean
   }) => Promise<{
     success: boolean
     error?: string
@@ -630,6 +631,7 @@ export function UiStateProvider({
       newBranchName?: string
       createWorktree?: boolean
       createWorkingCommit: boolean
+      runInitialization: boolean
     }): Promise<{
       success: boolean
       error?: string


### PR DESCRIPTION
## Summary

- Adds Repository tab in Settings dialog for per-repo worktree configuration
- Configure files to copy from main worktree (e.g., `.env`, `.env.local`)
- Configure setup commands to run after worktree creation (e.g., `pnpm install`)
- Set default "create working commit" option per repository
- Initialization runs in background after worktree creation

## Changes

- **RepositorySettings**: New component for configuring files to copy and setup commands
- **SettingsDialog**: Added tab navigation (General, Repository), wider dialog
- **NewBranchDialog**: Integration with initialization config, shows summary and toggle
- **WorktreeOperation**: Added `runInitialization()` for copying files and running commands
- **store.ts**: Added `worktreeInitConfigs` schema with getter/setter methods
- **IPC**: Added `getWorktreeInitConfig` and `setWorktreeInitConfig` channels
- **Types**: Added `WorktreeInitConfig` and `WorktreeInitializationResult` types

## Test plan

- [ ] Open Settings → Repository tab appears when repo is selected
- [ ] Add files to copy (e.g., `.env`) → Verify saved
- [ ] Add setup commands (e.g., `pnpm install`) → Verify saved
- [ ] Create worktree with "Run initialization" checked → Files copied, commands run
- [ ] Verify initialization runs in background (dialog closes immediately)
- [ ] Test partial failure (missing file) → Warning toast, worktree still created

## Stack

This PR is stacked on #346

🤖 Generated with [Claude Code](https://claude.ai/code)

- `main` <!-- branch-stack -->
  - \#346
    - \#347 :point\_left:
