### PR TITLE
fix: amend mid-stack rebases entire descendant stack

### DIFF
--- a/src/node/__tests__/e2e/rebase-e2e.test.ts
+++ b/src/node/__tests__/e2e/rebase-e2e.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../store', () => ({
 }))
 
 import { getGitAdapter, resetGitAdapter, type GitAdapter } from '../../adapters/git'
+import { CommitOperation } from '../../operations/CommitOperation'
 import { RebaseOperation } from '../../operations/RebaseOperation'
 import { ExecutionContextService } from '../../services/ExecutionContextService'
 
@@ -1107,4 +1108,73 @@ describe('Edge Cases and Error Handling', () => {
       expect(submitResult.success).toBeDefined()
     }
   })
+})
+
+// ============================================================================
+// 9. Amend Mid-Stack Cascades Entire Stack
+// ============================================================================
+
+describe('Amend Mid-Stack Cascades Entire Stack', () => {
+  let repo: TestRepo
+
+  beforeEach(async () => {
+    repo = await createTestRepo()
+    mockActiveWorktree = null
+    mockRebaseSessions.clear()
+  })
+
+  afterEach(async () => {
+    await cleanupTestRepo(repo)
+    mockRebaseSessions.clear()
+  })
+
+  it('amending bottom of a 4-deep stack rebases all descendants', async () => {
+    // Setup:
+    //   main(A) → branch-1(B) → branch-2(C) → branch-3(D) → branch-4(E)
+    //
+    // After amending branch-1 (B → B'), the entire stack should be rebased:
+    //   main(A) → branch-1(B') → branch-2(C') → branch-3(D') → branch-4(E')
+    //
+    // Regression: previously only branch-2 was rebased, leaving branch-3
+    // and branch-4 dangling on old SHAs
+
+    repo.commitFile('base.txt', 'base', 'trunk commit A')
+
+    repo.createBranch('branch-1')
+    repo.commitFile('file1.txt', 'content v1', 'commit B')
+
+    repo.createBranch('branch-2')
+    repo.commitFile('file2.txt', 'content 2', 'commit C')
+
+    repo.createBranch('branch-3')
+    repo.commitFile('file3.txt', 'content 3', 'commit D')
+
+    repo.createBranch('branch-4')
+    repo.commitFile('file4.txt', 'content 4', 'commit E')
+
+    // Go back to branch-1, stage changes, and amend
+    repo.checkout('branch-1')
+    fs.writeFileSync(path.join(repo.repoPath, 'file1.txt'), 'content v2')
+    repo.run('git add file1.txt')
+
+    await CommitOperation.amend(repo.repoPath, 'commit B (amended)')
+
+    // Verify branch-1 was amended
+    expect(repo.getCommitMessage('branch-1')).toBe('commit B (amended)')
+
+    // Verify the entire stack is connected end-to-end
+    // branch-4 should be exactly 4 commits ahead of main
+    const totalCount = repo.run('git rev-list --count main..branch-4')
+    expect(totalCount).toBe('4')
+
+    // Verify each parent linkage through the stack
+    expect(repo.getParentSha('branch-2')).toBe(repo.getSha('branch-1'))
+    expect(repo.getParentSha('branch-3')).toBe(repo.getSha('branch-2'))
+    expect(repo.getParentSha('branch-4')).toBe(repo.getSha('branch-3'))
+
+    // Verify commit messages are preserved
+    expect(repo.getCommitMessage('branch-2')).toBe('commit C')
+    expect(repo.getCommitMessage('branch-3')).toBe('commit D')
+    expect(repo.getCommitMessage('branch-4')).toBe('commit E')
+  }, 30000)
 })

--- a/src/node/__tests__/operations/CommitOperation.test.ts
+++ b/src/node/__tests__/operations/CommitOperation.test.ts
@@ -185,6 +185,115 @@ describe('amend', () => {
     }).trim()
     expect(childParent).toBe(parentHead)
   })
+
+  it('should rebase entire stack when amending a commit mid-stack', { timeout: 30000 }, async () => {
+    // Setup: 4-branch deep stack
+    //   main(A) → branch-1(B) → branch-2(C) → branch-3(D) → branch-4(E)
+    //
+    // After amending branch-1 (B → B'), the entire stack should be rebased:
+    //   main(A) → branch-1(B') → branch-2(C') → branch-3(D') → branch-4(E')
+    //
+    // Bug scenario: Only branch-2 gets rebased, leaving branch-3 and branch-4
+    // pointing to old SHAs (D and E still have parents C and D, not C' and D')
+
+    // Create trunk commit
+    const baseFile = path.join(repoPath, 'base.txt')
+    await fs.promises.writeFile(baseFile, 'base')
+    execSync('git add base.txt', { cwd: repoPath })
+    execSync('git commit -m "trunk commit A"', { cwd: repoPath })
+
+    // Create branch-1
+    execSync('git checkout -b branch-1', { cwd: repoPath })
+    const file1 = path.join(repoPath, 'file1.txt')
+    await fs.promises.writeFile(file1, 'content v1')
+    execSync('git add file1.txt', { cwd: repoPath })
+    execSync('git commit -m "commit B"', { cwd: repoPath })
+
+    // Create branch-2 stacked on branch-1
+    execSync('git checkout -b branch-2', { cwd: repoPath })
+    const file2 = path.join(repoPath, 'file2.txt')
+    await fs.promises.writeFile(file2, 'content 2')
+    execSync('git add file2.txt', { cwd: repoPath })
+    execSync('git commit -m "commit C"', { cwd: repoPath })
+
+    // Create branch-3 stacked on branch-2
+    execSync('git checkout -b branch-3', { cwd: repoPath })
+    const file3 = path.join(repoPath, 'file3.txt')
+    await fs.promises.writeFile(file3, 'content 3')
+    execSync('git add file3.txt', { cwd: repoPath })
+    execSync('git commit -m "commit D"', { cwd: repoPath })
+
+    // Create branch-4 stacked on branch-3
+    execSync('git checkout -b branch-4', { cwd: repoPath })
+    const file4 = path.join(repoPath, 'file4.txt')
+    await fs.promises.writeFile(file4, 'content 4')
+    execSync('git add file4.txt', { cwd: repoPath })
+    execSync('git commit -m "commit E"', { cwd: repoPath })
+
+    // Go back to branch-1, stage changes, and amend
+    execSync('git checkout branch-1', { cwd: repoPath })
+    await fs.promises.writeFile(file1, 'content v2')
+    execSync('git add file1.txt', { cwd: repoPath })
+
+    await CommitOperation.amend(repoPath, 'commit B (amended)')
+
+    // Verify branch-1 has the amended message
+    const msg1 = execSync('git log -1 --format=%s branch-1', {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    }).trim()
+    expect(msg1).toBe('commit B (amended)')
+
+    // Verify each branch in the stack is properly connected
+    // branch-2 should be 1 commit on top of branch-1
+    const count2 = execSync('git rev-list --count branch-1..branch-2', {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    }).trim()
+    expect(count2).toBe('1')
+
+    // branch-3 should be 1 commit on top of branch-2
+    const count3 = execSync('git rev-list --count branch-2..branch-3', {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    }).trim()
+    expect(count3).toBe('1')
+
+    // branch-4 should be 1 commit on top of branch-3
+    const count4 = execSync('git rev-list --count branch-3..branch-4', {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    }).trim()
+    expect(count4).toBe('1')
+
+    // Verify the full chain: branch-4 should be exactly 4 commits ahead of main
+    const totalCount = execSync('git rev-list --count main..branch-4', {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    }).trim()
+    expect(totalCount).toBe('4')
+
+    // Verify parent linkage is correct through the whole stack
+    const branch1Head = execSync('git rev-parse branch-1', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    const branch2Parent = execSync('git rev-parse branch-2~1', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(branch2Parent).toBe(branch1Head)
+
+    const branch2Head = execSync('git rev-parse branch-2', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    const branch3Parent = execSync('git rev-parse branch-3~1', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(branch3Parent).toBe(branch2Head)
+
+    const branch3Head = execSync('git rev-parse branch-3', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    const branch4Parent = execSync('git rev-parse branch-4~1', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(branch4Parent).toBe(branch3Head)
+
+    // Verify all commit messages are preserved
+    const msg2 = execSync('git log -1 --format=%s branch-2', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(msg2).toBe('commit C')
+    const msg3 = execSync('git log -1 --format=%s branch-3', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(msg3).toBe('commit D')
+    const msg4 = execSync('git log -1 --format=%s branch-4', { cwd: repoPath, encoding: 'utf-8' }).trim()
+    expect(msg4).toBe('commit E')
+  })
 })
 
 describe('uncommit', () => {

--- a/src/node/domain/StackAnalyzer.ts
+++ b/src/node/domain/StackAnalyzer.ts
@@ -334,6 +334,32 @@ export class StackAnalyzer {
   }
 
   /**
+   * Builds a StackNodeState tree from pre-computed indices, starting from a given branch.
+   * Returns the children of the given branch as StackNodeState nodes (not including
+   * the branch itself). Each node's baseSha is set to its parent's headSha.
+   */
+  public static buildNodeTree(
+    parentBranchName: string,
+    childrenIndex: Map<string, string[]>,
+    branchByRef: Map<string, { ref: string; headSha: string }>
+  ): StackNodeState[] {
+    const parentBranch = branchByRef.get(parentBranchName)
+    if (!parentBranch) return []
+
+    const childNames = childrenIndex.get(parentBranchName) ?? []
+    return childNames.map((childName) => {
+      const child = branchByRef.get(childName)!
+      return {
+        branch: childName,
+        headSha: child.headSha,
+        baseSha: parentBranch.headSha,
+        ownedShas: [],
+        children: StackAnalyzer.buildNodeTree(childName, childrenIndex, branchByRef)
+      }
+    })
+  }
+
+  /**
    * Finds child branches that stem directly from a given parent commit.
    * A child branch is one whose head's parent is the parentHeadSha.
    */

--- a/src/node/operations/CommitOperation.ts
+++ b/src/node/operations/CommitOperation.ts
@@ -186,9 +186,13 @@ export class CommitOperation {
     oldHeadSha: string
   ): RebaseTarget[] {
     const targets: RebaseTarget[] = []
+    const commitMap = new Map(repo.commits.map((c) => [c.sha, c]))
+    const parentIndex = StackAnalyzer.buildParentIndex(repo.branches, commitMap)
+    const childrenIndex = StackAnalyzer.buildChildrenIndex(parentIndex)
+    const branchByRef = new Map(repo.branches.map((b) => [b.ref, b]))
 
     for (const childName of childrenToRebase) {
-      const childBranch = repo.branches.find((b) => b.ref === childName)
+      const childBranch = branchByRef.get(childName)
       if (!childBranch?.headSha) continue
 
       // Use the old (pre-amend) HEAD SHA as the base for the rebase, not the
@@ -198,13 +202,16 @@ export class CommitOperation {
       // walk past the old HEAD and include it in the child's owned commits,
       // causing the rebase to replay the old HEAD on top of the new one —
       // creating a bogus duplicate commit and spurious conflicts.
+      //
+      // Build the full descendant tree so the executor can cascade rebases
+      // through the entire stack, not just the direct children.
       targets.push({
         node: {
           branch: childName,
           headSha: childBranch.headSha,
           baseSha: oldHeadSha,
           ownedShas: [],
-          children: []
+          children: StackAnalyzer.buildNodeTree(childName, childrenIndex, branchByRef)
         },
         targetBaseSha: newHeadSha
       })


### PR DESCRIPTION
When amending a commit mid-stack, only the direct child branch was getting rebased. Grandchildren and beyond were left dangling on old SHAs — the stack looked fine at depth 2 but was broken from depth 3 onward.

The cause was `buildRebaseTargets` in `CommitOperation` creating rebase target nodes with `children: []`. The executor already had cascading logic via `enqueueDescendants` that fires after each job completes, but it checked `node.children.length > 0` — which was always false, so the cascade never happened.

The fix builds the full descendant tree using `StackAnalyzer.buildParentIndex` + `buildChildrenIndex` (existing utilities), exposed via a new `StackAnalyzer.buildNodeTree` method. Now the executor sees the children and cascades rebases through the entire stack.

Added a unit test (4-deep stack amend) and an e2e test that reproduces the exact failure on `main` and passes with the fix.

- `main` <!-- branch-stack -->
  - \#366 :point\_left:
